### PR TITLE
Add dependabot config to update dependencies automatically.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "cargo"
+  directory: "/"
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
This  adds a simple dependabot config to open PRs to update cargo dependencies to the latest version automatically.