### PR TITLE
Correct master to main in github actions config.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       - "*"
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build_and_test:


### PR DESCRIPTION
Fixes github actions config to accurately reflect that the default branch, against which PRs are made, is named `main`.