### PR TITLE
Cluster support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,8 @@ url = "2.2.2"
 tracing = "0.1"
 thiserror = "1.0"
 async-trait = "0.1.51"
-
+rand = "0.8"
 
 [dev-dependencies]
 tracing-subscriber = "0.2.0"
 fake = { version = "2.4", features=['derive']}
-rand = "0.8"

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,6 +68,10 @@ pub enum ProducerCreateError {
         stream: String,
         status: ResponseCode,
     },
+
+    #[error("Stream {stream} does not exist")]
+    StreamDoesNotExist { stream: String },
+
     #[error(transparent)]
     Client(#[from] ClientError),
 }
@@ -105,6 +109,10 @@ pub enum ConsumerCreateError {
         stream: String,
         status: ResponseCode,
     },
+
+    #[error("Stream {stream} does not exist")]
+    StreamDoesNotExist { stream: String },
+
     #[error(transparent)]
     Client(#[from] ClientError),
 }


### PR DESCRIPTION
Implements #97 , as well as including some needed API changes - for example, configuration of host and port to connect to, and manual crediting for consumers.