### PR TITLE
Implement publish batching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,14 @@ license = "Apache-2.0 OR MPL-2.0"
 [workspace]
 members = [
  ".",
- "protocol"
+ "protocol",
+ "benchmark"
 ]
 
 
 [dependencies]
 rabbitmq-stream-protocol = { version = "0.1" , path = "protocol" }
-tokio = { version = "1.9.0", features = ["full"] }
+tokio = { version = "1.12.0", features = ["full"] }
 tokio-util = {  version = "0.6.7", features = ["codec"] }
 bytes = "1.0.0"
 tokio-stream = "0.1.7"
@@ -25,6 +26,7 @@ tracing = "0.1"
 thiserror = "1.0"
 async-trait = "0.1.51"
 rand = "0.8"
+dashmap = "4.0.2"
 
 [dev-dependencies]
 tracing-subscriber = "0.3.1"

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ test: build
 watch: build
 	cargo watch -x 'test --all -- --nocapture'
 
+
+run-benchmark:
+	cargo run --release -p benchmark
+
 rabbitmq-server:
 	docker run -it --rm --name rabbitmq-stream-go-client-test \
 		-p 5552:5552 -p 5672:5672 -p 15672:15672 \

--- a/README.md
+++ b/README.md
@@ -105,3 +105,10 @@ make build
 make rabbitmq-server
 make test
 ```
+
+#### Running Benchmarks
+
+```bash
+make rabbitmq-server
+make run-benchmark
+```

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "benchmark"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+rabbitmq-stream-client = { path = "../" }
+tracing-subscriber = "0.3.1"
+tracing = "0.1"
+tokio = { version = "1.12.0", features = ["full"] }
+clap = "3.0.0-beta.5"
+futures = "0.3.0"
+

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -13,4 +13,4 @@ tracing = "0.1"
 tokio = { version = "1.12.0", features = ["full"] }
 clap = "3.0.0-beta.5"
 futures = "0.3.0"
-
+async-trait = "0.1.51"

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -1,0 +1,155 @@
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use clap::Parser;
+
+use futures::StreamExt;
+use rabbitmq_stream_client::{types::Message, Environment};
+use tracing::info;
+use tracing_subscriber::FmtSubscriber;
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let opts = Opts::parse();
+    let subscriber = FmtSubscriber::builder().finish();
+
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
+    let environment = Environment::builder()
+        .host("localhost")
+        .port(5552)
+        .build()
+        .await?;
+
+    let stats = Stats::default();
+    start_reporting_task(stats.clone()).await;
+
+    start_publisher(
+        environment.clone(),
+        &opts,
+        opts.streams.get(0).unwrap().clone(),
+        stats.clone(),
+    )
+    .await?;
+
+    start_consumer(
+        environment,
+        &opts,
+        opts.streams.get(0).unwrap().clone(),
+        stats,
+    )
+    .await?;
+    loop {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+    }
+}
+#[derive(Parser, Debug)]
+#[clap(version = "1.0", author = "Enrico R.  <enrico.risa@gmail.com>")]
+struct Opts {
+    #[clap(short, long, default_value = "default.conf")]
+    urls: Vec<String>,
+    #[clap(short, long, default_value = "benchmark_stream")]
+    streams: Vec<String>,
+
+    #[clap(short, long, default_value = "100")]
+    batch_size: usize,
+}
+
+#[derive(Clone, Default)]
+pub struct Stats {
+    published_count: Arc<AtomicU64>,
+    confirmed_message_count: Arc<AtomicU64>,
+    consumer_message_count: Arc<AtomicU64>,
+}
+
+async fn start_publisher(
+    env: Environment,
+    opts: &Opts,
+    stream: String,
+    stats: Stats,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = env.stream_creator().create(&stream).await;
+
+    let batch_size = opts.batch_size;
+    let producer = env
+        .producer()
+        .batch_size(opts.batch_size)
+        .build(&stream)
+        .await?;
+
+    tokio::task::spawn(async move {
+        loop {
+            let mut msg = Vec::with_capacity(batch_size as usize);
+            for _ in 0..batch_size {
+                let time = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos();
+                msg.push(Message::builder().body(time.to_be_bytes()).build());
+            }
+
+            let inner_stats = stats.clone();
+            producer
+                .batch_send_with_callback(msg, move |confirmation_status| {
+                    let stats = inner_stats.clone();
+                    async move {
+                        if confirmation_status.unwrap().confirmed() {
+                            stats
+                                .confirmed_message_count
+                                .fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                })
+                .await
+                .unwrap();
+
+            stats
+                .published_count
+                .fetch_add(batch_size as u64, Ordering::Relaxed);
+        }
+    });
+    Ok(())
+}
+async fn start_consumer(
+    env: Environment,
+    _opts: &Opts,
+    stream: String,
+    stats: Stats,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut consumer = env.consumer().build(&stream).await?;
+
+    tokio::task::spawn(async move {
+        loop {
+            while consumer.next().await.is_some() {
+                stats.consumer_message_count.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    });
+    Ok(())
+}
+
+async fn start_reporting_task(stats: Stats) {
+    tokio::task::spawn(async move {
+        let start = Instant::now();
+        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        loop {
+            interval.tick().await;
+
+            let diff = Instant::now() - start;
+            let sec = diff.as_secs();
+            if sec > 0 {
+                info!(
+                    "Published {} msg/s, Confirmed {} msg/s, Consumed {} msg/s, elapsed {}",
+                    stats.published_count.load(Ordering::Relaxed) / sec,
+                    stats.confirmed_message_count.load(Ordering::Relaxed) / sec,
+                    stats.consumer_message_count.load(Ordering::Relaxed) / sec,
+                    sec
+                );
+            }
+        }
+    });
+}

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -89,6 +89,7 @@ async fn start_publisher(
                     .duration_since(UNIX_EPOCH)
                     .unwrap()
                     .as_nanos();
+
                 msg.push(Message::builder().body(time.to_be_bytes()).build());
             }
 

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -93,7 +93,7 @@ async fn single_send(producer: &Producer<NoDedup>, batch_size: usize) {
             .as_nanos();
 
         producer
-            .send_with_callback(
+            .send(
                 Message::builder().body(time.to_be_bytes()).build(),
                 move |_| async move {},
             )
@@ -113,7 +113,7 @@ async fn batch_send(producer: &Producer<NoDedup>, batch_size: usize) {
     }
 
     producer
-        .batch_send_with_callback(msg, move |_| async move {})
+        .batch_send(msg, move |_| async move {})
         .await
         .unwrap();
 }

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -41,7 +41,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[derive(Parser, Debug)]
 #[clap(version = "1.0", author = "Enrico R.  <enrico.risa@gmail.com>")]
 struct Opts {
-    #[clap(short, long, default_value = "default.conf")]
+    // Ignored for now.
+    #[clap(short, long, default_value = "")]
     urls: Vec<String>,
     #[clap(short, long, default_value = "benchmark_stream")]
     streams: Vec<String>,

--- a/benchmark/src/stats.rs
+++ b/benchmark/src/stats.rs
@@ -1,0 +1,67 @@
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use rabbitmq_stream_client::MetricsCollector;
+use tracing::info;
+
+#[derive(Clone)]
+pub struct Stats {
+    start_time: Arc<AtomicU64>,
+    published_count: Arc<AtomicU64>,
+    confirmed_message_count: Arc<AtomicU64>,
+    consumer_message_count: Arc<AtomicU64>,
+}
+
+impl Default for Stats {
+    fn default() -> Self {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        Self {
+            start_time: Arc::new(AtomicU64::new(now as u64)),
+            published_count: Default::default(),
+            confirmed_message_count: Default::default(),
+            consumer_message_count: Default::default(),
+        }
+    }
+}
+impl Stats {
+    pub fn dump(&self) {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+        let start = Duration::from_nanos(self.start_time.load(Ordering::Relaxed));
+        let diff = now - start;
+        let sec = diff.as_millis() as u64;
+
+        info!(
+            "Published {} msg/s, Confirmed {} msg/s, Consumed {} msg/s, elapsed {}",
+            self.published_count.load(Ordering::Relaxed) * 1000 / sec,
+            self.confirmed_message_count.load(Ordering::Relaxed) * 1000 / sec,
+            self.consumer_message_count.load(Ordering::Relaxed) * 1000 / sec,
+            diff.as_secs()
+        );
+    }
+}
+
+#[async_trait::async_trait]
+impl MetricsCollector for Stats {
+    async fn publish(&self, count: u64) {
+        self.published_count.fetch_add(count, Ordering::Relaxed);
+    }
+
+    async fn consume(&self, count: u64) {
+        self.consumer_message_count
+            .fetch_add(count, Ordering::Relaxed);
+    }
+
+    async fn publish_confirm(&self, count: u64) {
+        self.confirmed_message_count
+            .fetch_add(count, Ordering::Relaxed);
+    }
+    async fn publish_error(&self, _count: u64) {}
+}

--- a/benchmark/src/stats.rs
+++ b/benchmark/src/stats.rs
@@ -36,13 +36,13 @@ impl Stats {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
         let start = Duration::from_nanos(self.start_time.load(Ordering::Relaxed));
         let diff = now - start;
-        let sec = diff.as_millis() as u64;
+        let millis = diff.as_millis() as u64;
 
         info!(
             "Published {} msg/s, Confirmed {} msg/s, Consumed {} msg/s, elapsed {}",
-            self.published_count.load(Ordering::Relaxed) * 1000 / sec,
-            self.confirmed_message_count.load(Ordering::Relaxed) * 1000 / sec,
-            self.consumer_message_count.load(Ordering::Relaxed) * 1000 / sec,
+            self.published_count.load(Ordering::Relaxed) * 1000 / millis,
+            self.confirmed_message_count.load(Ordering::Relaxed) * 1000 / millis,
+            self.consumer_message_count.load(Ordering::Relaxed) * 1000 / millis,
             diff.as_secs()
         );
     }

--- a/examples/batch.rs
+++ b/examples/batch.rs
@@ -1,8 +1,11 @@
+use std::sync::Arc;
+
 use futures::StreamExt;
 use rabbitmq_stream_client::{
     types::{ByteCapacity, Message, OffsetSpecification},
     Environment,
 };
+use tokio::sync::Barrier;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
@@ -19,31 +22,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()
         .await?;
 
+    let _ = environment.delete_stream("batch_test").await;
     let message_count = 10;
     environment
         .stream_creator()
         .max_length(ByteCapacity::GB(2))
-        .create("test")
+        .create("batch_test")
         .await?;
 
-    let producer = environment
-        .producer()
-        .name("test_producer")
-        .build("test")
-        .await?;
+    let producer = environment.producer().build("batch_test").await?;
 
+    let barrier = Arc::new(Barrier::new(message_count + 1));
     for i in 0..message_count {
-        producer
-            .send(Message::builder().body(format!("message{}", i)).build())
-            .await?;
+        let producer_cloned = producer.clone();
+
+        let barrier_cloned = barrier.clone();
+        tokio::task::spawn(async move {
+            producer_cloned
+                .send(Message::builder().body(format!("message{}", i)).build())
+                .await
+                .unwrap();
+
+            barrier_cloned.wait().await;
+        });
     }
+
+    barrier.wait().await;
 
     producer.close().await?;
 
     let mut consumer = environment
         .consumer()
         .offset(OffsetSpecification::First)
-        .build("test")
+        .build("batch_test")
         .await
         .unwrap();
 
@@ -61,6 +72,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     consumer.handle().close().await.unwrap();
 
-    environment.delete_stream("test").await?;
+    environment.delete_stream("batch_test").await?;
     Ok(())
 }

--- a/examples/batch.rs
+++ b/examples/batch.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let barrier_cloned = barrier.clone();
         tokio::task::spawn(async move {
             producer_cloned
-                .send(Message::builder().body(format!("message{}", i)).build())
+                .send_with_confirm(Message::builder().body(format!("message{}", i)).build())
                 .await
                 .unwrap();
 

--- a/examples/batch_send.rs
+++ b/examples/batch_send.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     producer
-        .batch_send_with_callback(messages, |confirmation_status| async move {
+        .batch_send(messages, |confirmation_status| async move {
             info!("Message confirmed with status {:?}", confirmation_status);
         })
         .await?;

--- a/examples/batch_send.rs
+++ b/examples/batch_send.rs
@@ -1,0 +1,69 @@
+use futures::StreamExt;
+use rabbitmq_stream_client::{
+    types::{ByteCapacity, Message, OffsetSpecification},
+    Environment,
+};
+use tracing::{info, Level};
+use tracing_subscriber::FmtSubscriber;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::TRACE)
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+    let environment = Environment::builder()
+        .host("localhost")
+        .port(5552)
+        .build()
+        .await?;
+
+    let _ = environment.delete_stream("batch_send").await;
+    let message_count = 10;
+    environment
+        .stream_creator()
+        .max_length(ByteCapacity::GB(2))
+        .create("batch_send")
+        .await?;
+
+    let producer = environment.producer().build("batch_send").await?;
+
+    let mut messages = Vec::with_capacity(message_count);
+    for i in 0..message_count {
+        let msg = Message::builder().body(format!("message{}", i)).build();
+        messages.push(msg);
+    }
+
+    producer
+        .batch_send_with_callback(messages, |confirmation_status| async move {
+            info!("Message confirmed with status {:?}", confirmation_status);
+        })
+        .await?;
+
+    producer.close().await?;
+
+    let mut consumer = environment
+        .consumer()
+        .offset(OffsetSpecification::First)
+        .build("batch_send")
+        .await
+        .unwrap();
+
+    for _ in 0..message_count {
+        let delivery = consumer.next().await.unwrap()?;
+        info!(
+            "Got message : {:?} with offset {}",
+            delivery
+                .message()
+                .data()
+                .map(|data| String::from_utf8(data.to_vec())),
+            delivery.offset()
+        );
+    }
+
+    consumer.handle().close().await.unwrap();
+
+    environment.delete_stream("batch_send").await?;
+    Ok(())
+}

--- a/examples/env_callback.rs
+++ b/examples/env_callback.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for i in 0..message_count {
         let b_cloned = barrier.clone();
         producer
-            .send_with_callback(
+            .send(
                 Message::builder().body(format!("message{}", i)).build(),
                 move |confirm_result| {
                     let inner_barrier = b_cloned.clone();

--- a/examples/environment.rs
+++ b/examples/environment.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for i in 0..message_count {
         producer
-            .send(Message::builder().body(format!("message{}", i)).build())
+            .send_with_confirm(Message::builder().body(format!("message{}", i)).build())
             .await?;
     }
 

--- a/protocol/src/codec/decoder.rs
+++ b/protocol/src/codec/decoder.rs
@@ -62,7 +62,7 @@ impl Decoder for Vec<u8> {
 pub fn read_vec<T: Decoder>(input: &[u8]) -> Result<(&[u8], Vec<T>), DecodeError> {
     let (mut input, len) = read_i32(input)?;
     let len = len as usize;
-    let mut result: Vec<T> = Vec::new();
+    let mut result: Vec<T> = Vec::with_capacity(len);
     for _ in 0..len {
         let (input1, value) = T::decode(input)?;
         result.push(value);

--- a/protocol/src/commands/deliver.rs
+++ b/protocol/src/commands/deliver.rs
@@ -21,7 +21,7 @@ pub struct DeliverCommand {
     num_entries: u16,
     timestamp: u64,
     epoch: u64,
-    chunk_first_offset: u64,
+    pub chunk_first_offset: u64,
     chunk_crc: i32,
     trailer_length: u32,
     reserved: u32,
@@ -121,7 +121,7 @@ impl Decoder for DeliverCommand {
         let (input, trailer_length) = u32::decode(input)?;
         let (mut input, reserved) = u32::decode(input)?;
 
-        let mut messages = Vec::new();
+        let mut messages = Vec::with_capacity(num_records as usize);
         for _ in 0..num_records {
             let (input1, result) = read_vec(input)?;
             let (_, message) = Message::decode(&result)?;

--- a/src/client/metrics.rs
+++ b/src/client/metrics.rs
@@ -1,11 +1,17 @@
 #[async_trait::async_trait]
 pub trait MetricsCollector: Send + Sync {
     async fn publish(&self, count: u64);
+    async fn consume(&self, count: u64);
+    async fn publish_confirm(&self, count: u64);
+    async fn publish_error(&self, count: u64);
 }
-
 pub struct NopMetricsCollector {}
 
 #[async_trait::async_trait]
 impl MetricsCollector for NopMetricsCollector {
     async fn publish(&self, _count: u64) {}
+    async fn publish_confirm(&self, _count: u64) {}
+    async fn publish_error(&self, _count: u64) {}
+
+    async fn consume(&self, _count: u64) {}
 }

--- a/src/client/metrics.rs
+++ b/src/client/metrics.rs
@@ -1,0 +1,11 @@
+#[async_trait::async_trait]
+pub trait MetricsCollector: Send + Sync {
+    async fn publish(&self, count: u64);
+}
+
+pub struct NopMetricsCollector {}
+
+#[async_trait::async_trait]
+impl MetricsCollector for NopMetricsCollector {
+    async fn publish(&self, _count: u64) {}
+}

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -1,4 +1,8 @@
-#[derive(Clone, Debug)]
+use std::{fmt::Debug, sync::Arc};
+
+use super::metrics::{MetricsCollector, NopMetricsCollector};
+
+#[derive(Clone)]
 pub struct ClientOptions {
     pub(crate) host: String,
     pub(crate) port: u16,
@@ -7,8 +11,22 @@ pub struct ClientOptions {
     pub(crate) v_host: String,
     pub(crate) heartbeat: u32,
     pub(crate) max_frame_size: u32,
+    pub(crate) collector: Arc<dyn MetricsCollector>,
 }
 
+impl Debug for ClientOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientOptions")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("user", &self.user)
+            .field("password", &self.password)
+            .field("v_host", &self.v_host)
+            .field("heartbeat", &self.heartbeat)
+            .field("max_frame_size", &self.max_frame_size)
+            .finish()
+    }
+}
 impl Default for ClientOptions {
     fn default() -> Self {
         ClientOptions {
@@ -19,6 +37,7 @@ impl Default for ClientOptions {
             v_host: "/".to_owned(),
             heartbeat: 60,
             max_frame_size: 1048576,
+            collector: Arc::new(NopMetricsCollector {}),
         }
     }
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -113,15 +113,7 @@ impl EnvironmentBuilder {
         self
     }
 }
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct EnvironmentOptions {
     pub(crate) client_options: ClientOptions,
-}
-
-impl Default for EnvironmentOptions {
-    fn default() -> Self {
-        Self {
-            client_options: ClientOptions::default(),
-        }
-    }
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,11 +1,12 @@
 use std::marker::PhantomData;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::producer::NoDedup;
 use crate::types::OffsetSpecification;
 
 use crate::{
-    client::{Client, ClientOptions},
+    client::{Client, ClientOptions, MetricsCollector},
     consumer::ConsumerBuilder,
     error::StreamDeleteError,
     producer::ProducerBuilder,
@@ -101,6 +102,14 @@ impl EnvironmentBuilder {
     }
     pub fn port(mut self, port: u16) -> EnvironmentBuilder {
         self.0.client_options.port = port;
+        self
+    }
+
+    pub fn metrics_collector(
+        mut self,
+        collector: impl MetricsCollector + Send + Sync + 'static,
+    ) -> EnvironmentBuilder {
+        self.0.client_options.collector = Arc::new(collector);
         self
     }
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,3 +1,7 @@
+use std::marker::PhantomData;
+use std::time::Duration;
+
+use crate::producer::NoDedup;
 use crate::types::OffsetSpecification;
 
 use crate::{
@@ -32,10 +36,13 @@ impl Environment {
     }
 
     /// Returns a builder for creating a producer
-    pub fn producer(&self) -> ProducerBuilder {
+    pub fn producer(&self) -> ProducerBuilder<NoDedup> {
         ProducerBuilder {
             environment: self.clone(),
             name: None,
+            batch_size: 100,
+            batch_publishing_delay: Duration::from_millis(100),
+            data: PhantomData,
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,6 +84,8 @@ pub enum ProducerPublishError {
         publisher_id: u8,
         status: ResponseCode,
     },
+    #[error("Failed to send batch messages for stream {stream}")]
+    Batch { stream: String },
     #[error("Failed to publish message, the producer is closed")]
     Closed,
     #[error(transparent)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -88,6 +88,8 @@ pub enum ProducerPublishError {
     Batch { stream: String },
     #[error("Failed to publish message, the producer is closed")]
     Closed,
+    #[error("Failed to publish message, confirmation channel returned None for stream {stream}")]
+    Confirmation { stream: String },
     #[error(transparent)]
     Client(#[from] ClientError),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ mod stream_creator;
 
 pub type RabbitMQStreamResult<T> = Result<T, error::ClientError>;
 
-pub use crate::client::{Client, ClientOptions};
+pub use crate::client::{Client, ClientOptions, MetricsCollector};
 
 pub use crate::consumer::{Consumer, ConsumerBuilder, ConsumerHandle};
 pub use crate::environment::{Environment, EnvironmentBuilder};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! for i in 0..10 {
 //!     producer
-//!         .send(Message::builder().body(format!("message{}", i)).build())
+//!         .send_with_confirm(Message::builder().body(format!("message{}", i)).build())
 //!         .await?;
 //! }
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub use crate::client::{Client, ClientOptions};
 
 pub use crate::consumer::{Consumer, ConsumerBuilder, ConsumerHandle};
 pub use crate::environment::{Environment, EnvironmentBuilder};
-pub use crate::producer::{Producer, ProducerBuilder};
+pub use crate::producer::{Dedup, NoDedup, Producer, ProducerBuilder};
 pub mod types {
 
     pub use crate::byte_capacity::ByteCapacity;

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -248,7 +248,10 @@ fn schedule_batch_send(producer: Arc<ProducerInternal>, delay: Duration) {
 }
 
 impl<T> Producer<T> {
-    pub async fn send(&self, message: Message) -> Result<ConfirmationStatus, ProducerPublishError> {
+    pub async fn send_with_confirm(
+        &self,
+        message: Message,
+    ) -> Result<ConfirmationStatus, ProducerPublishError> {
         let (tx, mut rx) = channel(1);
         let _ = self
             .internal_send(message, move |status| {
@@ -268,7 +271,7 @@ impl<T> Producer<T> {
             .map(Ok)?
     }
 
-    pub async fn batch_send(
+    pub async fn batch_send_with_confirm(
         &self,
         messages: Vec<Message>,
     ) -> Result<Vec<ConfirmationStatus>, ProducerPublishError> {
@@ -292,7 +295,7 @@ impl<T> Producer<T> {
 
         Ok(confirmations)
     }
-    pub async fn batch_send_with_callback<Fut>(
+    pub async fn batch_send<Fut>(
         &self,
         messages: Vec<Message>,
         cb: impl Fn(Result<ConfirmationStatus, ProducerPublishError>) -> Fut + Send + Sync + 'static,
@@ -305,7 +308,7 @@ impl<T> Producer<T> {
         Ok(())
     }
 
-    pub async fn send_with_callback<Fut>(
+    pub async fn send<Fut>(
         &self,
         message: Message,
         cb: impl Fn(Result<ConfirmationStatus, ProducerPublishError>) -> Fut + Send + Sync + 'static,

--- a/tests/integration/consumer_test.rs
+++ b/tests/integration/consumer_test.rs
@@ -32,7 +32,7 @@ async fn consumer_test() {
 
     for n in 0..message_count {
         let _ = producer
-            .send(Message::builder().body(format!("message{}", n)).build())
+            .send_with_confirm(Message::builder().body(format!("message{}", n)).build())
             .await
             .unwrap();
     }
@@ -62,7 +62,7 @@ async fn consumer_close_test() {
         .unwrap();
 
     let _ = producer
-        .send(Message::builder().body("message").build())
+        .send_with_confirm(Message::builder().body("message").build())
         .await
         .unwrap();
 

--- a/tests/integration/consumer_test.rs
+++ b/tests/integration/consumer_test.rs
@@ -39,7 +39,7 @@ async fn consumer_test() {
 
     for _ in 0..message_count {
         let delivery = consumer.next().await.unwrap();
-        let data = String::from_utf8(delivery.unwrap().message.data().unwrap().to_vec()).unwrap();
+        let data = String::from_utf8(delivery.unwrap().message().data().unwrap().to_vec()).unwrap();
         assert!(data.contains("message"));
     }
 
@@ -50,15 +50,8 @@ async fn consumer_test() {
 #[tokio::test(flavor = "multi_thread")]
 async fn consumer_close_test() {
     let env = TestEnvironment::create().await;
-    let reference: String = Faker.fake();
 
-    let producer = env
-        .env
-        .producer()
-        .name(&reference)
-        .build(&env.stream)
-        .await
-        .unwrap();
+    let producer = env.env.producer().build(&env.stream).await.unwrap();
 
     let mut consumer = env
         .env

--- a/tests/integration/producer_test.rs
+++ b/tests/integration/producer_test.rs
@@ -27,8 +27,8 @@ async fn producer_send_no_name_ok() {
     producer.close().await.unwrap();
 
     let delivery = consumer.next().await.unwrap().unwrap();
-    assert_eq!(1, delivery.subscription_id);
-    assert_eq!(Some(b"message".as_ref()), delivery.message.data());
+    assert_eq!(1, delivery.subscription_id());
+    assert_eq!(Some(b"message".as_ref()), delivery.message().data());
 
     consumer.handle().close().await.unwrap();
 }
@@ -77,12 +77,12 @@ async fn producer_send_name_with_deduplication_ok() {
     producer.close().await.unwrap();
 
     let delivery = consumer.next().await.unwrap().unwrap();
-    assert_eq!(1, delivery.subscription_id);
-    assert_eq!(Some(b"message0".as_ref()), delivery.message.data());
+    assert_eq!(1, delivery.subscription_id());
+    assert_eq!(Some(b"message0".as_ref()), delivery.message().data());
 
     let delivery = consumer.next().await.unwrap().unwrap();
-    assert_eq!(1, delivery.subscription_id);
-    assert_eq!(Some(b"message1".as_ref()), delivery.message.data());
+    assert_eq!(1, delivery.subscription_id());
+    assert_eq!(Some(b"message1".as_ref()), delivery.message().data());
 
     consumer.handle().close().await.unwrap();
 }
@@ -115,7 +115,7 @@ async fn producer_send_with_callback() {
 
     let result = rx.recv().await.unwrap();
 
-    assert_eq!(0, result.unwrap());
+    assert_eq!(0, result.unwrap().publishing_id());
 
     producer.close().await.unwrap();
 }

--- a/tests/integration/producer_test.rs
+++ b/tests/integration/producer_test.rs
@@ -20,7 +20,7 @@ async fn producer_send_no_name_ok() {
         .unwrap();
 
     let _ = producer
-        .send(Message::builder().body(b"message".to_vec()).build())
+        .send_with_confirm(Message::builder().body(b"message".to_vec()).build())
         .await
         .unwrap();
 
@@ -54,13 +54,13 @@ async fn producer_send_name_with_deduplication_ok() {
         .unwrap();
 
     let _ = producer
-        .send(Message::builder().body(b"message0".to_vec()).build())
+        .send_with_confirm(Message::builder().body(b"message0".to_vec()).build())
         .await
         .unwrap();
 
     // this is not published
     let _ = producer
-        .send(
+        .send_with_confirm(
             Message::builder()
                 .body(b"message0".to_vec())
                 .publising_id(0)
@@ -70,7 +70,7 @@ async fn producer_send_name_with_deduplication_ok() {
         .unwrap();
 
     let _ = producer
-        .send(Message::builder().body(b"message1".to_vec()).build())
+        .send_with_confirm(Message::builder().body(b"message1".to_vec()).build())
         .await
         .unwrap();
 
@@ -101,7 +101,7 @@ async fn producer_send_with_callback() {
         .unwrap();
 
     let _ = producer
-        .send_with_callback(
+        .send(
             Message::builder().body(b"message".to_vec()).build(),
             move |confirm_result| {
                 let inner_tx = tx.clone();
@@ -128,7 +128,7 @@ async fn producer_batch_send_with_callback() {
     let producer = env.env.producer().build(&env.stream).await.unwrap();
 
     let _ = producer
-        .batch_send_with_callback(
+        .batch_send(
             vec![Message::builder().body(b"message".to_vec()).build()],
             move |confirm_result| {
                 let inner_tx = tx.clone();
@@ -154,7 +154,7 @@ async fn producer_batch_send() {
     let producer = env.env.producer().build(&env.stream).await.unwrap();
 
     let result = producer
-        .batch_send(vec![Message::builder().body(b"message".to_vec()).build()])
+        .batch_send_with_confirm(vec![Message::builder().body(b"message".to_vec()).build()])
         .await
         .unwrap();
 


### PR DESCRIPTION
This PR add automatic batching on send. By default the batch size is `100` and it will cache the messages before sending them to the broker. The configuration on the producer `batch_delay`, which is by default `100ms` which is the schedule delay for the batch messages.

This PR also add two APIs on the `producer` for sending directly to the broker messages in batch, avoiding the delay mechanism.

Also the initial work for a benchmark tool has been done.