### PR TITLE
Implement some clippy pedantic recommendations.

### DIFF
--- a/protocol/src/codec/encoder.rs
+++ b/protocol/src/codec/encoder.rs
@@ -157,7 +157,7 @@ impl Encoder for HashMap<String, String> {
 
 impl Encoder for Option<String> {
     fn encoded_size(&self) -> u32 {
-        2 + self.as_ref().map(|string| string.len() as u32).unwrap_or(0)
+        2 + self.as_ref().map_or(0, |string| string.len() as u32)
     }
 
     fn encode(&self, writer: &mut impl Write) -> Result<(), EncodeError> {

--- a/protocol/src/message/amqp/types/descriptor.rs
+++ b/protocol/src/message/amqp/types/descriptor.rs
@@ -38,9 +38,10 @@ impl AmqpDecoder for Descriptor {
             (input, TypeCode::Described) => {
                 let (remaining, code) = TypeCode::decode(input)?;
                 match code {
-                    TypeCode::ULong => ULong::decode(input).map_second(Descriptor::Ulong),
+                    TypeCode::ULong | TypeCode::ULongSmall => {
+                        ULong::decode(input).map_second(Descriptor::Ulong)
+                    }
                     TypeCode::ULong0 => Ok((remaining, Descriptor::Ulong(0))),
-                    TypeCode::ULongSmall => ULong::decode(input).map_second(Descriptor::Ulong),
                     TypeCode::Symbol8 | TypeCode::Symbol32 => {
                         Symbol::decode(input).map_second(Descriptor::Symbol)
                     }

--- a/protocol/src/message/amqp/types/primitives/simple.rs
+++ b/protocol/src/message/amqp/types/primitives/simple.rs
@@ -503,7 +503,7 @@ pub type Binary = Vec<u8>;
 
 impl<T: AmqpEncoder> AmqpEncoder for Option<T> {
     fn encoded_size(&self) -> u32 {
-        self.as_ref().map(T::encoded_size).unwrap_or(1)
+        self.as_ref().map_or(1, T::encoded_size)
     }
 
     fn encode(&self, writer: &mut impl std::io::Write) -> Result<(), AmqpEncodeError> {

--- a/src/client/message.rs
+++ b/src/client/message.rs
@@ -7,7 +7,7 @@ pub trait BaseMessage {
 
 impl BaseMessage for Message {
     fn publishing_id(&self) -> Option<u64> {
-        self.publishing_id().cloned()
+        self.publishing_id().copied()
     }
 
     fn to_message(self) -> Message {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -298,7 +298,7 @@ impl Client {
             .collect();
         let sequences = messages
             .iter()
-            .map(|message| message.publishing_id())
+            .map(rabbitmq_stream_protocol::types::PublishedMessage::publishing_id)
             .collect();
         let len = messages.len();
 


### PR DESCRIPTION
Implemented recommendations:
* combine duplicate match arms
* map.unrwap_or -> map_or
* change cloned -> copy when used with iterators
* remove redundant closures for method calls
* pass by reference when not consuming to avoid unnecessary allocations.