### PR TITLE
Thread-safe Consumer

### DIFF
--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -23,9 +23,8 @@ use crate::{
     Client, ClientOptions, Environment, MetricsCollector,
 };
 use futures::{task::AtomicWaker, Stream};
-use rand::rngs::ThreadRng;
-
-use rand::seq::SliceRandom;
+use rand::rngs::StdRng;
+use rand::{seq::SliceRandom, SeedableRng};
 
 /// API for consuming RabbitMQ stream messages
 pub struct Consumer {
@@ -64,7 +63,7 @@ impl ConsumerBuilder {
         if let Some(metadata) = client.metadata(vec![stream.to_string()]).await?.get(stream) {
             // If there are no replicas we do not reassign client, meaning we just keep reading from the leader.
             // This is desired behavior in case there is only one node in the cluster.
-            if let Some(replica) = metadata.replicas.choose(&mut ThreadRng::default()) {
+            if let Some(replica) = metadata.replicas.choose(&mut StdRng::from_entropy()) {
                 tracing::debug!(
                     "Picked replica {:?} out of possible candidates {:?} for stream {}",
                     replica,

--- a/tests/integration/consumer_test.rs
+++ b/tests/integration/consumer_test.rs
@@ -4,8 +4,9 @@ use crate::common::TestEnvironment;
 use fake::{Fake, Faker};
 use futures::StreamExt;
 use rabbitmq_stream_client::{
-    error::{ConsumerCloseError, ProducerCloseError},
-    types::{Message, OffsetSpecification},
+    error::{ConsumerCloseError, ConsumerDeliveryError, ProducerCloseError},
+    types::{Delivery, Message, OffsetSpecification},
+    Consumer, NoDedup, Producer,
 };
 
 #[tokio::test(flavor = "multi_thread")]
@@ -92,4 +93,57 @@ async fn consumer_close_test() {
         producer.close().await,
         Err(ProducerCloseError::AlreadyClosed),
     ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn consumer_thread_safe_test() {
+    let message_body = "test0";
+
+    struct Wrapper {
+        producer: Producer<NoDedup>,
+        consumer: Consumer,
+    }
+
+    impl Wrapper {
+        pub async fn init() -> Self {
+            let env = TestEnvironment::create().await;
+            let producer = env.env.producer().build(&env.stream).await.unwrap();
+            let consumer = env
+                .env
+                .consumer()
+                .offset(OffsetSpecification::Next)
+                .build(&env.stream)
+                .await
+                .unwrap();
+            Self { producer, consumer }
+        }
+
+        pub async fn produce(&mut self, body: &str) {
+            self.producer
+                .send_with_confirm(Message::builder().body(body).build())
+                .await
+                .unwrap();
+        }
+
+        pub async fn consume(&mut self) -> Option<Result<Delivery, ConsumerDeliveryError>> {
+            self.consumer.next().await
+        }
+
+        pub async fn close(self) {
+            self.producer.close().await.unwrap();
+            self.consumer.handle().close().await.unwrap();
+        }
+    }
+
+    // move the Wrapper struct to test that Consumer and Producer are thread-safe
+    tokio::spawn(async move {
+        let mut wrapper = Wrapper::init().await;
+        wrapper.produce(message_body).await;
+        let delivery = wrapper.consume().await.unwrap();
+
+        let data = String::from_utf8(delivery.unwrap().message().data().unwrap().to_vec()).unwrap();
+        assert_eq!(data, message_body);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        wrapper.close().await;
+    });
 }


### PR DESCRIPTION
ThreadRng is not Send - so e.g. spawning a Tokio task with the `Consumer` or a structure which it's a member of fails to compile (I've tried to model this in an integration test).

Fixed by using a `StdRng` which is thread-safe.

