### PR TITLE
tls_first_implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["network-programming"]
 readme = "README.md"
 
 
+
 [workspace]
 members = [
  ".",
@@ -20,11 +21,13 @@ members = [
 
 
 [dependencies]
+tokio-native-tls = "0.3.0"
 rabbitmq-stream-protocol = { version = "0.1" , path = "protocol" }
 tokio = { version = "1.12.0", features = ["full"] }
 tokio-util = {  version = "0.7.3", features = ["codec"] }
 bytes = "1.0.0"
-tokio-stream = "0.1.7"
+pin-project = { version = "1.0.0" }
+tokio-stream = "0.1.11"
 futures = "0.3.0"
 url = "2.2.2"
 tracing = "0.1"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -396,13 +396,11 @@ impl Client {
                 .danger_accept_invalid_certs(true)
                 .danger_accept_invalid_hostnames(true);
 
-            let conn = tls_builder.build();
+            let conn = tokio_native_tls::TlsConnector::from(tls_builder.build()?);
 
-            let conn = tokio_native_tls::TlsConnector::from(conn.unwrap());
+            let stream = conn.connect(broker.host.as_str(), stream).await?;
 
-            let stream = conn.connect(broker.host.as_str(), stream).await;
-
-            GenericTcpStream::SecureTcp(stream.unwrap())
+            GenericTcpStream::SecureTcp(stream)
         } else {
             let stream = TcpStream::connect((broker.host.as_str(), broker.port)).await?;
             GenericTcpStream::Tcp(stream)

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -51,17 +51,73 @@ use self::{
     message::BaseMessage,
 };
 
+use pin_project::pin_project;
 use std::{
     collections::HashMap,
+    io,
+    pin::Pin,
     sync::{atomic::AtomicU64, Arc},
+    task::{Context, Poll},
 };
 use std::{future::Future, sync::atomic::Ordering};
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+use tokio::io::ReadBuf;
 use tokio::sync::RwLock;
 use tokio::{net::TcpStream, sync::Notify};
+use tokio_native_tls::TlsStream;
 use tokio_util::codec::Framed;
 
-type SinkConnection = SplitSink<Framed<TcpStream, RabbitMqStreamCodec>, Request>;
-type StreamConnection = SplitStream<Framed<TcpStream, RabbitMqStreamCodec>>;
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio-stream")))]
+#[pin_project(project = StreamProj)]
+#[derive(Debug)]
+enum GenericTcpStream {
+    Tcp(#[pin] TcpStream),
+    SecureTcp(#[pin] TlsStream<TcpStream>),
+}
+
+impl AsyncRead for GenericTcpStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match self.project() {
+            StreamProj::Tcp(tcp_stream) => tcp_stream.poll_read(cx, buf),
+            StreamProj::SecureTcp(tls_stream) => tls_stream.poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for GenericTcpStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.project() {
+            StreamProj::Tcp(tcp_stream) => tcp_stream.poll_write(cx, buf),
+            StreamProj::SecureTcp(tls_stream) => tls_stream.poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.project() {
+            StreamProj::Tcp(tcp_stream) => tcp_stream.poll_flush(cx),
+            StreamProj::SecureTcp(tls_stream) => tls_stream.poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.project() {
+            StreamProj::Tcp(tcp_stream) => tcp_stream.poll_shutdown(cx),
+            StreamProj::SecureTcp(tls_stream) => tls_stream.poll_shutdown(cx),
+        }
+    }
+}
+
+type SinkConnection = SplitSink<Framed<GenericTcpStream, RabbitMqStreamCodec>, Request>;
+type StreamConnection = SplitStream<Framed<GenericTcpStream, RabbitMqStreamCodec>>;
 
 pub struct ClientState {
     server_properties: HashMap<String, String>,
@@ -332,7 +388,26 @@ impl Client {
         ),
         ClientError,
     > {
-        let stream = TcpStream::connect((broker.host.as_str(), broker.port)).await?;
+        let stream = if broker.tls.enabled() {
+            let stream = TcpStream::connect((broker.host.as_str(), broker.port)).await?;
+
+            let mut tls_builder = tokio_native_tls::native_tls::TlsConnector::builder();
+            tls_builder
+                .danger_accept_invalid_certs(true)
+                .danger_accept_invalid_hostnames(true);
+
+            let conn = tls_builder.build();
+
+            let conn = tokio_native_tls::TlsConnector::from(conn.unwrap());
+
+            let stream = conn.connect(broker.host.as_str(), stream).await;
+
+            GenericTcpStream::SecureTcp(stream.unwrap())
+        } else {
+            let stream = TcpStream::connect((broker.host.as_str(), broker.port)).await?;
+            GenericTcpStream::Tcp(stream)
+        };
+
         let stream = Framed::new(stream, RabbitMqStreamCodec {});
 
         let (sink, stream) = stream.split();

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Debug, sync::Arc};
 
 use super::metrics::{MetricsCollector, NopMetricsCollector};
+use crate::environment::TlsConfiguration;
 
 #[derive(Clone)]
 pub struct ClientOptions {
@@ -11,6 +12,7 @@ pub struct ClientOptions {
     pub(crate) v_host: String,
     pub(crate) heartbeat: u32,
     pub(crate) max_frame_size: u32,
+    pub(crate) tls: TlsConfiguration,
     pub(crate) collector: Arc<dyn MetricsCollector>,
 }
 
@@ -38,6 +40,25 @@ impl Default for ClientOptions {
             heartbeat: 60,
             max_frame_size: 1048576,
             collector: Arc::new(NopMetricsCollector {}),
+            tls: TlsConfiguration {
+                enabled: false,
+                hostname_verification: false,
+                trust_everything: false,
+            },
         }
+    }
+}
+
+impl ClientOptions {
+    pub fn get_tls(&self) -> TlsConfiguration {
+        self.tls
+    }
+
+    pub fn enable_tls(&mut self) {
+        self.tls.enable(true);
+    }
+
+    pub fn set_port(&mut self, port: u16) {
+        self.port = port;
     }
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -105,6 +105,23 @@ impl EnvironmentBuilder {
         self
     }
 
+    pub fn tls(mut self, tls_configuration: TlsConfiguration) -> EnvironmentBuilder {
+        self.0
+            .client_options
+            .tls
+            .trust_everything(tls_configuration.trust_everything_enabled());
+        self.0
+            .client_options
+            .tls
+            .hostname_verification_enable(tls_configuration.hostname_verification_enabled());
+        self.0
+            .client_options
+            .tls
+            .enable(tls_configuration.enabled());
+
+        self
+    }
+
     pub fn metrics_collector(
         mut self,
         collector: impl MetricsCollector + Send + Sync + 'static,
@@ -116,4 +133,48 @@ impl EnvironmentBuilder {
 #[derive(Clone, Default)]
 pub struct EnvironmentOptions {
     pub(crate) client_options: ClientOptions,
+}
+
+/** Helper for tls configuration */
+#[derive(Clone, Copy)]
+pub struct TlsConfiguration {
+    pub(crate) enabled: bool,
+    pub(crate) hostname_verification: bool,
+    pub(crate) trust_everything: bool,
+}
+
+impl Default for TlsConfiguration {
+    fn default() -> TlsConfiguration {
+        TlsConfiguration {
+            enabled: true,
+            trust_everything: false,
+            hostname_verification: true,
+        }
+    }
+}
+
+impl TlsConfiguration {
+    pub fn trust_everything(&mut self, trust_everything: bool) {
+        self.trust_everything = trust_everything
+    }
+
+    pub fn enable(&mut self, enabled: bool) {
+        self.enabled = enabled
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn hostname_verification_enable(&mut self, hostname_verification: bool) {
+        self.hostname_verification = hostname_verification
+    }
+
+    pub fn hostname_verification_enabled(&self) -> bool {
+        self.hostname_verification
+    }
+
+    pub fn trust_everything_enabled(&self) -> bool {
+        self.trust_everything
+    }
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -178,3 +178,35 @@ impl TlsConfiguration {
         self.trust_everything
     }
 }
+
+pub struct TlsConfigurationBuilder(TlsConfiguration);
+
+impl TlsConfigurationBuilder {
+    pub fn trust_everything(mut self, trust_everything: bool) -> TlsConfigurationBuilder {
+        self.0.trust_everything = trust_everything;
+        self
+    }
+
+    pub fn enable(mut self, enable: bool) -> TlsConfigurationBuilder {
+        self.0.enabled = enable;
+        self
+    }
+
+    pub fn hostname_verification_enable(
+        mut self,
+        hostname_verification: bool,
+    ) -> TlsConfigurationBuilder {
+        self.0.hostname_verification = hostname_verification;
+        self
+    }
+
+    pub fn build(self) -> TlsConfiguration {
+        self.0
+    }
+}
+
+impl TlsConfiguration {
+    pub fn builder() -> TlsConfigurationBuilder {
+        TlsConfigurationBuilder(TlsConfiguration::default())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,15 +8,17 @@ use thiserror::Error;
 pub enum ClientError {
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
     #[error(transparent)]
     Protocol(#[from] ProtocolError),
     #[error("Cast Error: {0}")]
     CastError(String),
-
     #[error(transparent)]
     GenericError(#[from] Box<dyn std::error::Error + Send + Sync>),
     #[error("Client already closed")]
     AlreadyClosed,
+    #[error("tls_error")]
+    Tls(tokio_native_tls::native_tls::Error),
 }
 
 #[derive(Error, Debug)]
@@ -30,6 +32,12 @@ pub enum ProtocolError {
 impl From<EncodeError> for ClientError {
     fn from(err: EncodeError) -> Self {
         ClientError::Protocol(ProtocolError::Encode(err))
+    }
+}
+
+impl From<tokio_native_tls::native_tls::Error> for ClientError {
+    fn from(err: tokio_native_tls::native_tls::Error) -> Self {
+        ClientError::Tls(err)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub type RabbitMQStreamResult<T> = Result<T, error::ClientError>;
 pub use crate::client::{Client, ClientOptions, MetricsCollector};
 
 pub use crate::consumer::{Consumer, ConsumerBuilder, ConsumerHandle};
-pub use crate::environment::{Environment, EnvironmentBuilder};
+pub use crate::environment::{Environment, EnvironmentBuilder, TlsConfiguration};
 pub use crate::producer::{Dedup, NoDedup, Producer, ProducerBuilder};
 pub mod types {
 


### PR DESCRIPTION
This first implementation of TLS support includes:

- Integrate the tokio-native-tls library
- Implements an Environment Helper Class "TlsConfiguration" to manage Tls options in Environment
- Implements Tls trusting all hostnames and certificates at the moment (just encryption offered)
- Adding a test on port 5551