### PR TITLE
Add more tests for the Environment

### DIFF
--- a/examples/environment.rs
+++ b/examples/environment.rs
@@ -1,7 +1,7 @@
 use futures::StreamExt;
 use rabbitmq_stream_client::{
     types::{ByteCapacity, Message, OffsetSpecification},
-    Environment, TlsConfiguration,
+    Environment,
 };
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
@@ -16,7 +16,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let environment = Environment::builder()
         .host("localhost")
         .port(5552)
-        // .tls(TlsConfiguration::default())
         .build()
         .await?;
 

--- a/examples/environment.rs
+++ b/examples/environment.rs
@@ -1,7 +1,7 @@
 use futures::StreamExt;
 use rabbitmq_stream_client::{
     types::{ByteCapacity, Message, OffsetSpecification},
-    Environment,
+    Environment, TlsConfiguration,
 };
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
@@ -16,6 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let environment = Environment::builder()
         .host("localhost")
         .port(5552)
+        // .tls(TlsConfiguration::default())
         .build()
         .await?;
 


### PR DESCRIPTION
-  `environment_create_streams_with_parameters` create stream with parameter
- `environment_fail_tls_connection` fail to connect in a non-TLS server

About TLS, we could consider to setup a server with TLS in the CI. but it is out of scope for this PR