### PR TITLE
add tests for producer

### DIFF
--- a/tests/integration/client_test.rs
+++ b/tests/integration/client_test.rs
@@ -241,6 +241,53 @@ async fn client_declare_delete_publisher() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn client_declare_delete_publisher_twice_error() {
+    // test the errors in case of double publisher declaration
+    // the first one is ok the second one is not
+    // since the publisher id is already used
+
+    let test = TestClient::create().await;
+    let reference: String = Faker.fake();
+
+    let response = test
+        .client
+        .declare_publisher(1, Some(reference.clone()), &test.stream)
+        .await
+        .unwrap();
+
+    assert_eq!(&ResponseCode::Ok, response.code());
+
+    let response_error = test
+        .client
+        .declare_publisher(1, Some(reference.clone()), &test.stream)
+        .await
+        .unwrap();
+
+    assert_eq!(&ResponseCode::PrecoditionFailed, response_error.code());
+
+    let response = test.client.delete_publisher(1).await.unwrap();
+    assert_eq!(&ResponseCode::Ok, response.code());
+
+    let response_error = test.client.delete_publisher(1).await.unwrap();
+    assert_eq!(&ResponseCode::PublisherDoesNotExist, response_error.code());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn client_declare_publisher_not_existing_stream() {
+    let test = TestClient::create().await;
+
+    let reference: String = Faker.fake();
+
+    let response = test
+        .client
+        .declare_publisher(1, Some(reference.clone()), "not_existing_stream")
+        .await
+        .unwrap();
+
+    assert_eq!(&ResponseCode::StreamDoesNotExist, response.code());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn client_query_publisher() {
     let test = TestClient::create().await;
 

--- a/tests/integration/producer_test.rs
+++ b/tests/integration/producer_test.rs
@@ -119,7 +119,6 @@ async fn producer_send_batch_name_with_deduplication_ok() {
                 .body(b"message".to_vec())
                 .publising_id(1)
                 .build(),
-
             // not confirmed since the publishing id is the same
             // message will be skipped by deduplication
             Message::builder()

--- a/tests/integration/producer_test.rs
+++ b/tests/integration/producer_test.rs
@@ -42,7 +42,7 @@ async fn producer_send_name_with_deduplication_ok() {
     let mut producer = env
         .env
         .producer()
-        .name("myconsumer")
+        .name("my_producer")
         .build(&env.stream)
         .await
         .unwrap();
@@ -87,6 +87,50 @@ async fn producer_send_name_with_deduplication_ok() {
     assert_eq!(Some(b"message1".as_ref()), delivery.message().data());
 
     consumer.handle().close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn producer_send_batch_name_with_deduplication_ok() {
+    let env = TestEnvironment::create().await;
+
+    let mut producer = env
+        .env
+        .producer()
+        .name("my_producer")
+        .build(&env.stream)
+        .await
+        .unwrap();
+
+    let result = producer
+        .batch_send_with_confirm(vec![
+            // confirmed
+            Message::builder()
+                .body(b"message".to_vec())
+                .publising_id(0)
+                .build(),
+            // this won't be confirmed
+            // since it will skipped by deduplication
+            Message::builder()
+                .body(b"message".to_vec())
+                .publising_id(0)
+                .build(),
+            // confirmed since the publishing id is different
+            Message::builder()
+                .body(b"message".to_vec())
+                .publising_id(1)
+                .build(),
+
+            // not confirmed since the publishing id is the same
+            // message will be skipped by deduplication
+            Message::builder()
+                .body(b"message".to_vec())
+                .publising_id(1)
+                .build(),
+        ])
+        .await
+        .unwrap();
+    // only 2 messages are confirmed
+    assert_eq!(2, result.len());
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
This PR adds more tests for the producer when:

- try to use the same id
- try to close twice 
- try to use it after close 
- test the deduplication with send batch 


There is a commented test:
```
producer_deduplication_send_after_close_error
```

because it does not work like the producer I will check it and open another PR