### PR TITLE
Use an explicit type annotation here

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -234,7 +234,7 @@ impl MessageAccumulator {
             .await
             .map_err(|err| ClientError::GenericError(Box::new(err)))?;
 
-        let val = self.message_count.fetch_add(1, Ordering::Relaxed);
+        let val: usize = self.message_count.fetch_add(1, Ordering::Relaxed);
 
         Ok(val + 1 == self.capacity)
     }


### PR DESCRIPTION
References #186.

One hypothesis in #186 was that compiler's type inference fails to determine that the value should be a `usize`. Since `AtomicUsize#fetch_add` returns a `usize`, I highly doubt it is a compiler issue. Instead, the cloning/concurrency factors are more important. 

That said, this was trivial to put together, so why not use this PR to verify the hypothesis.