### PR TITLE
producer: Safely check if message accumulator is full

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -236,7 +236,7 @@ impl MessageAccumulator {
 
         let val = self.message_count.fetch_add(1, Ordering::Relaxed);
 
-        Ok(val + 1 == self.capacity)
+        Ok(val >= self.capacity - 1)
     }
     pub async fn get(&self) -> RabbitMQStreamResult<Option<ClientMessage>> {
         let mut receiver = self.receiver.lock().await;


### PR DESCRIPTION
`val + 1` could overflow in `val == usize::MAX`. We can switch the check to `val >= self.capacity - 1` because we know that `capacity` is non-zero: `mpsc::channel` would panic in `MessageAccumulator::new` if `batch_size` were `0`.

Connects #186