### PR TITLE
Raw client example: set handler before subscribtion

### DIFF
--- a/examples/raw_client.rs
+++ b/examples/raw_client.rs
@@ -56,10 +56,6 @@ async fn start_subscriber(
     client: &Client,
     notifier: Arc<Notify>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let _ = client
-        .subscribe(1, stream, OffsetSpecification::Next, 1, HashMap::new())
-        .await?;
-
     let client_inner = client.clone();
     let notifier_inner = notifier.clone();
     let counter = Arc::new(AtomicI32::new(0));
@@ -92,7 +88,11 @@ async fn start_subscriber(
         }
         Ok(())
     };
-
     client.set_handler(handler).await;
+
+    let _ = client
+        .subscribe(1, stream, OffsetSpecification::Next, 1, HashMap::new())
+        .await?;
+
     Ok(())
 }


### PR DESCRIPTION
It's important to remember that you need to set a handler before subscribing. Otherwise, some messages may be lost.

In this example, we perform publishing after subscribing, so losing messages is not possible. Nonetheless, it's better to adhere to this order.