### PR TITLE
Superstream: Create/Delete superstream and Partition and route commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:3.13-rc-management
+FROM rabbitmq:4.0.1-management
 
 COPY .ci/conf/rabbitmq.conf /etc/rabbitmq/rabbitmq.conf
 COPY .ci/conf/enabled_plugins /etc/rabbitmq/enabled_plugins

--- a/protocol/src/commands/create_super_stream.rs
+++ b/protocol/src/commands/create_super_stream.rs
@@ -88,7 +88,7 @@ impl Command for CreateSuperStreamCommand {
 
 #[cfg(test)]
 mod tests {
-    use crate::commands::create_stream::CreateStreamCommand;
+
     use crate::commands::tests::command_encode_decode_test;
 
     use super::CreateSuperStreamCommand;

--- a/protocol/src/commands/create_super_stream.rs
+++ b/protocol/src/commands/create_super_stream.rs
@@ -1,0 +1,100 @@
+use std::collections::HashMap;
+use std::io::Write;
+
+#[cfg(test)]
+use fake::Fake;
+
+use crate::{
+    codec::{Decoder, Encoder},
+    error::{DecodeError, EncodeError},
+    protocol::commands::COMMAND_CREATE_SUPER_STREAM,
+};
+
+use super::Command;
+
+#[cfg_attr(test, derive(fake::Dummy))]
+#[derive(PartialEq, Eq, Debug)]
+pub struct CreateSuperStreamCommand {
+    correlation_id: u32,
+    super_stream_name: String,
+    partitions: Vec<String>,
+    binding_keys: Vec<String>,
+    args: HashMap<String, String>,
+}
+
+impl CreateSuperStreamCommand {
+    pub fn new(
+        correlation_id: u32,
+        super_stream_name: String,
+        partitions: Vec<String>,
+        binding_keys: Vec<String>,
+        args: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            correlation_id,
+            super_stream_name,
+            partitions,
+            binding_keys,
+            args,
+        }
+    }
+}
+
+impl Encoder for CreateSuperStreamCommand {
+    fn encoded_size(&self) -> u32 {
+        self.correlation_id.encoded_size()
+            + self.super_stream_name.as_str().encoded_size()
+            + self.partitions.encoded_size()
+            + self.binding_keys.encoded_size()
+            + self.args.encoded_size()
+    }
+
+    fn encode(&self, writer: &mut impl Write) -> Result<(), EncodeError> {
+        self.correlation_id.encode(writer)?;
+        self.super_stream_name.as_str().encode(writer)?;
+        self.partitions.encode(writer)?;
+        self.binding_keys.encode(writer)?;
+        self.args.encode(writer)?;
+        Ok(())
+    }
+}
+
+impl Decoder for CreateSuperStreamCommand {
+    fn decode(input: &[u8]) -> Result<(&[u8], Self), DecodeError> {
+        let (input, correlation_id) = u32::decode(input)?;
+        let (input, super_stream_name) = Option::decode(input)?;
+        let (input, partitions) = <Vec<String>>::decode(input)?;
+        let (input, binding_keys) = <Vec<String>>::decode(input)?;
+        let (input, args) = HashMap::decode(input)?;
+
+        Ok((
+            input,
+            CreateSuperStreamCommand {
+                correlation_id,
+                super_stream_name: super_stream_name.unwrap(),
+                partitions,
+                binding_keys,
+                args,
+            },
+        ))
+    }
+}
+
+impl Command for CreateSuperStreamCommand {
+    fn key(&self) -> u16 {
+        COMMAND_CREATE_SUPER_STREAM
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::commands::create_stream::CreateStreamCommand;
+    use crate::commands::tests::command_encode_decode_test;
+
+    use super::CreateSuperStreamCommand;
+
+    #[test]
+    fn create_super_stream_request_test() {
+        command_encode_decode_test::<CreateSuperStreamCommand>();
+    }
+}

--- a/protocol/src/commands/delete_super_stream.rs
+++ b/protocol/src/commands/delete_super_stream.rs
@@ -1,0 +1,74 @@
+use std::io::Write;
+
+#[cfg(test)]
+use fake::Fake;
+
+use crate::{
+    codec::{Decoder, Encoder},
+    error::{DecodeError, EncodeError},
+    protocol::commands::COMMAND_DELETE_SUPER_STREAM,
+};
+
+use super::Command;
+
+#[cfg_attr(test, derive(fake::Dummy))]
+#[derive(PartialEq, Eq, Debug)]
+pub struct DeleteSuperStreamCommand {
+    correlation_id: u32,
+    super_stream_name: String,
+}
+
+impl DeleteSuperStreamCommand {
+    pub fn new(correlation_id: u32, super_stream_name: String) -> Self {
+        Self {
+            correlation_id,
+            super_stream_name,
+        }
+    }
+}
+
+impl Encoder for DeleteSuperStreamCommand {
+    fn encoded_size(&self) -> u32 {
+        self.correlation_id.encoded_size() + self.super_stream_name.as_str().encoded_size()
+    }
+
+    fn encode(&self, writer: &mut impl Write) -> Result<(), EncodeError> {
+        self.correlation_id.encode(writer)?;
+        self.super_stream_name.as_str().encode(writer)?;
+        Ok(())
+    }
+}
+
+impl Decoder for DeleteSuperStreamCommand {
+    fn decode(input: &[u8]) -> Result<(&[u8], Self), DecodeError> {
+        let (input, correlation_id) = u32::decode(input)?;
+        let (input, super_stream_name) = Option::decode(input)?;
+
+        Ok((
+            input,
+            DeleteSuperStreamCommand {
+                correlation_id,
+                super_stream_name: super_stream_name.unwrap(),
+            },
+        ))
+    }
+}
+
+impl Command for DeleteSuperStreamCommand {
+    fn key(&self) -> u16 {
+        COMMAND_DELETE_SUPER_STREAM
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::commands::create_super_stream::CreateSuperStreamCommand;
+    use crate::commands::tests::command_encode_decode_test;
+
+    use super::DeleteSuperStreamCommand;
+
+    #[test]
+    fn delete_super_stream_request_test() {
+        command_encode_decode_test::<DeleteSuperStreamCommand>();
+    }
+}

--- a/protocol/src/commands/mod.rs
+++ b/protocol/src/commands/mod.rs
@@ -25,6 +25,8 @@ pub mod sasl_authenticate;
 pub mod sasl_handshake;
 pub mod store_offset;
 pub mod subscribe;
+pub mod superstream_partitions;
+pub mod superstream_route;
 pub mod tune;
 pub mod unsubscribe;
 

--- a/protocol/src/commands/mod.rs
+++ b/protocol/src/commands/mod.rs
@@ -2,10 +2,12 @@ use crate::protocol::version::PROTOCOL_VERSION;
 
 pub mod close;
 pub mod create_stream;
+pub mod create_super_stream;
 pub mod credit;
 pub mod declare_publisher;
 pub mod delete;
 pub mod delete_publisher;
+pub mod delete_super_stream;
 pub mod deliver;
 pub mod exchange_command_versions;
 pub mod generic;

--- a/protocol/src/commands/superstream_partitions.rs
+++ b/protocol/src/commands/superstream_partitions.rs
@@ -1,0 +1,145 @@
+use std::io::Write;
+
+#[cfg(test)]
+use fake::Fake;
+
+use crate::{
+    codec::{Decoder, Encoder},
+    error::{DecodeError, EncodeError},
+    protocol::commands::COMMAND_PARTITIONS,
+    FromResponse, ResponseCode,
+};
+use crate::commands::exchange_command_versions::ExchangeCommandVersion;
+use super::Command;
+
+#[cfg_attr(test, derive(fake::Dummy))]
+#[derive(PartialEq, Eq, Debug)]
+pub struct SuperStreamPartitionsRequest {
+    correlation_id: u32,
+    super_stream: String,
+}
+
+impl SuperStreamPartitionsRequest {
+    pub fn new(correlation_id: u32, super_stream: String) -> Self {
+        Self {
+            correlation_id,
+            super_stream,
+        }
+    }
+}
+
+impl Encoder for SuperStreamPartitionsRequest {
+    fn encoded_size(&self) -> u32 {
+        self.correlation_id.encoded_size() + self.super_stream.as_str().encoded_size()
+    }
+
+    fn encode(&self, writer: &mut impl Write) -> Result<(), EncodeError> {
+        self.correlation_id.encode(writer)?;
+        self.super_stream.as_str().encode(writer)?;
+        Ok(())
+    }
+}
+
+impl Decoder for SuperStreamPartitionsRequest {
+    fn decode(input: &[u8]) -> Result<(&[u8], Self), DecodeError> {
+        let (input, correlation_id) = u32::decode(input)?;
+        let (input, super_stream) = Option::decode(input)?;
+
+        Ok((
+            input,
+            SuperStreamPartitionsRequest {
+                correlation_id,
+                super_stream: super_stream.unwrap(),
+            },
+        ))
+    }
+}
+
+impl Command for SuperStreamPartitionsRequest {
+    fn key(&self) -> u16 {
+        COMMAND_PARTITIONS
+    }
+}
+
+#[cfg_attr(test, derive(fake::Dummy))]
+#[derive(PartialEq, Eq, Debug)]
+pub struct SuperStreamPartitionsResponse {
+    pub(crate) correlation_id: u32,
+    response_code: ResponseCode,
+    pub streams: Vec<String>,
+}
+
+impl SuperStreamPartitionsResponse {
+    pub fn new(correlation_id: u32, streams: Vec<String>, response_code: ResponseCode) -> Self {
+        Self {
+            correlation_id,
+            response_code,
+            streams,
+        }
+    }
+    pub fn is_ok(&self) -> bool {
+        self.response_code == ResponseCode::Ok
+    }
+}
+
+impl Encoder for SuperStreamPartitionsResponse {
+    fn encode(&self, writer: &mut impl Write) -> Result<(), EncodeError> {
+        self.correlation_id.encode(writer)?;
+        self.response_code.encode(writer)?;
+        self.streams.encode(writer)?;
+        Ok(())
+    }
+
+    fn encoded_size(&self) -> u32 {
+        self.correlation_id.encoded_size()
+            + self.response_code.encoded_size()
+            + self.streams.encoded_size()
+    }
+}
+
+impl Decoder for SuperStreamPartitionsResponse {
+    fn decode(input: &[u8]) -> Result<(&[u8], Self), DecodeError> {
+        let (input, correlation_id) = u32::decode(input)?;
+        let (input, response_code) = ResponseCode::decode(input)?;
+        let (input, streams) = <Vec<String>>::decode(input)?;
+
+        Ok((
+            input,
+            SuperStreamPartitionsResponse {
+                correlation_id,
+                response_code,
+                streams,
+            },
+        ))
+    }
+}
+
+impl FromResponse for SuperStreamPartitionsResponse {
+    fn from_response(response: crate::Response) -> Option<Self> {
+        match response.kind {
+            crate::ResponseKind::SuperStreamPartitions(partitions_response) => {
+                Some(partitions_response)
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::commands::tests::command_encode_decode_test;
+
+    use super::SuperStreamPartitionsRequest;
+    use super::SuperStreamPartitionsResponse;
+
+    #[test]
+    fn super_stream_partition_request_test() {
+        command_encode_decode_test::<SuperStreamPartitionsRequest>();
+    }
+
+    #[test]
+    fn super_stream_partition_response_test() {
+        command_encode_decode_test::<SuperStreamPartitionsResponse>();
+    }
+}

--- a/protocol/src/commands/superstream_partitions.rs
+++ b/protocol/src/commands/superstream_partitions.rs
@@ -3,14 +3,13 @@ use std::io::Write;
 #[cfg(test)]
 use fake::Fake;
 
+use super::Command;
 use crate::{
     codec::{Decoder, Encoder},
     error::{DecodeError, EncodeError},
     protocol::commands::COMMAND_PARTITIONS,
     FromResponse, ResponseCode,
 };
-use crate::commands::exchange_command_versions::ExchangeCommandVersion;
-use super::Command;
 
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]

--- a/protocol/src/commands/superstream_route.rs
+++ b/protocol/src/commands/superstream_route.rs
@@ -1,0 +1,150 @@
+use std::io::Write;
+
+#[cfg(test)]
+use fake::Fake;
+
+use crate::{
+    codec::{Decoder, Encoder},
+    error::{DecodeError, EncodeError},
+    protocol::commands::COMMAND_ROUTE,
+    FromResponse, ResponseCode,
+};
+
+use super::Command;
+
+#[cfg_attr(test, derive(fake::Dummy))]
+#[derive(PartialEq, Eq, Debug)]
+pub struct SuperStreamRouteRequest {
+    correlation_id: u32,
+    routing_key: String,
+    super_stream: String,
+}
+
+impl SuperStreamRouteRequest {
+    pub fn new(correlation_id: u32, routing_key: String, super_stream: String) -> Self {
+        Self {
+            correlation_id,
+            routing_key,
+            super_stream,
+        }
+    }
+}
+
+impl Encoder for SuperStreamRouteRequest {
+    fn encoded_size(&self) -> u32 {
+        self.correlation_id.encoded_size()
+            + self.routing_key.as_str().encoded_size()
+            + self.super_stream.as_str().encoded_size()
+    }
+
+    fn encode(&self, writer: &mut impl Write) -> Result<(), EncodeError> {
+        self.correlation_id.encode(writer)?;
+        self.routing_key.as_str().encode(writer)?;
+        self.super_stream.as_str().encode(writer)?;
+        Ok(())
+    }
+}
+
+impl Decoder for SuperStreamRouteRequest {
+    fn decode(input: &[u8]) -> Result<(&[u8], Self), DecodeError> {
+        let (input, correlation_id) = u32::decode(input)?;
+        let (input, routing_key) = Option::decode(input)?;
+        let (input, super_stream) = Option::decode(input)?;
+
+        Ok((
+            input,
+            SuperStreamRouteRequest {
+                correlation_id,
+                routing_key: routing_key.unwrap(),
+                super_stream: super_stream.unwrap(),
+            },
+        ))
+    }
+}
+
+impl Command for SuperStreamRouteRequest {
+    fn key(&self) -> u16 {
+        COMMAND_ROUTE
+    }
+}
+
+#[cfg_attr(test, derive(fake::Dummy))]
+#[derive(PartialEq, Eq, Debug)]
+pub struct SuperStreamRouteResponse {
+    pub(crate) correlation_id: u32,
+    response_code: ResponseCode,
+    pub streams: Vec<String>,
+}
+
+impl SuperStreamRouteResponse {
+    pub fn new(correlation_id: u32, streams: Vec<String>, response_code: ResponseCode) -> Self {
+        Self {
+            correlation_id,
+            response_code,
+            streams,
+        }
+    }
+    pub fn is_ok(&self) -> bool {
+        self.response_code == ResponseCode::Ok
+    }
+}
+
+impl Encoder for SuperStreamRouteResponse {
+    fn encode(&self, writer: &mut impl Write) -> Result<(), EncodeError> {
+        self.correlation_id.encode(writer)?;
+        self.response_code.encode(writer)?;
+        self.streams.encode(writer)?;
+        Ok(())
+    }
+
+    fn encoded_size(&self) -> u32 {
+        self.correlation_id.encoded_size()
+            + self.streams.encoded_size()
+            + self.response_code.encoded_size()
+    }
+}
+
+impl Decoder for SuperStreamRouteResponse {
+    fn decode(input: &[u8]) -> Result<(&[u8], Self), DecodeError> {
+        let (input, correlation_id) = u32::decode(input)?;
+        let (input, response_code) = ResponseCode::decode(input)?;
+        let (input, streams) = Vec::decode(input)?;
+
+        Ok((
+            input,
+            SuperStreamRouteResponse {
+                correlation_id,
+                response_code,
+                streams,
+            },
+        ))
+    }
+}
+
+impl FromResponse for SuperStreamRouteResponse {
+    fn from_response(response: crate::Response) -> Option<Self> {
+        match response.kind {
+            crate::ResponseKind::SuperStreamRoute(route) => Some(route),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::commands::tests::command_encode_decode_test;
+
+    use super::SuperStreamRouteRequest;
+    use super::SuperStreamRouteResponse;
+
+    #[test]
+    fn super_stream_route_request_test() {
+        command_encode_decode_test::<SuperStreamRouteRequest>();
+    }
+
+    #[test]
+    fn super_stream_route_response_test() {
+        command_encode_decode_test::<SuperStreamRouteResponse>();
+    }
+}

--- a/protocol/src/protocol.rs
+++ b/protocol/src/protocol.rs
@@ -30,6 +30,8 @@ pub mod commands {
     pub const COMMAND_CONSUMER_UPDATE: u16 = 26;
     pub const COMMAND_EXCHANGE_COMMAND_VERSIONS: u16 = 27;
     pub const COMMAND_STREAMS_STATS: u16 = 28;
+    pub const COMMAND_CREATE_SUPER_STREAM: u16 = 29;
+    pub const COMMAND_DELETE_SUPER_STREAM: u16 = 30;
 }
 
 // server responses

--- a/protocol/src/request/shims.rs
+++ b/protocol/src/request/shims.rs
@@ -10,7 +10,9 @@ use crate::{
         publish::PublishCommand, query_offset::QueryOffsetRequest,
         query_publisher_sequence::QueryPublisherRequest,
         sasl_authenticate::SaslAuthenticateCommand, sasl_handshake::SaslHandshakeCommand,
-        store_offset::StoreOffset, subscribe::SubscribeCommand, tune::TunesCommand,
+        store_offset::StoreOffset, subscribe::SubscribeCommand,
+        superstream_partitions::SuperStreamPartitionsRequest,
+        superstream_route::SuperStreamRouteRequest, tune::TunesCommand,
         unsubscribe::UnSubscribeCommand, Command,
     },
     types::Header,
@@ -148,5 +150,17 @@ impl From<CreateSuperStreamCommand> for RequestKind {
 impl From<DeleteSuperStreamCommand> for RequestKind {
     fn from(cmd: DeleteSuperStreamCommand) -> Self {
         RequestKind::DeleteSuperStream(cmd)
+    }
+}
+
+impl From<SuperStreamPartitionsRequest> for RequestKind {
+    fn from(cmd: SuperStreamPartitionsRequest) -> Self {
+        RequestKind::SuperStreamPartitions(cmd)
+    }
+}
+
+impl From<SuperStreamRouteRequest> for RequestKind {
+    fn from(cmd: SuperStreamRouteRequest) -> Self {
+        RequestKind::SuperStreamRoute(cmd)
     }
 }

--- a/protocol/src/request/shims.rs
+++ b/protocol/src/request/shims.rs
@@ -1,3 +1,5 @@
+use crate::commands::create_super_stream::CreateSuperStreamCommand;
+use crate::commands::delete_super_stream::DeleteSuperStreamCommand;
 use crate::{
     commands::{
         close::CloseRequest, create_stream::CreateStreamCommand, credit::CreditCommand,
@@ -14,6 +16,7 @@ use crate::{
     types::Header,
     Request, RequestKind,
 };
+
 impl<T> From<T> for Request
 where
     T: Into<RequestKind> + Command,
@@ -133,5 +136,17 @@ impl From<UnSubscribeCommand> for RequestKind {
 impl From<ExchangeCommandVersionsRequest> for RequestKind {
     fn from(cmd: ExchangeCommandVersionsRequest) -> Self {
         RequestKind::ExchangeCommandVersions(cmd)
+    }
+}
+
+impl From<CreateSuperStreamCommand> for RequestKind {
+    fn from(cmd: CreateSuperStreamCommand) -> Self {
+        RequestKind::CreateSuperStream(cmd)
+    }
+}
+
+impl From<DeleteSuperStreamCommand> for RequestKind {
+    fn from(cmd: DeleteSuperStreamCommand) -> Self {
+        RequestKind::DeleteSuperStream(cmd)
     }
 }

--- a/protocol/src/response/mod.rs
+++ b/protocol/src/response/mod.rs
@@ -13,12 +13,14 @@ use crate::{
         peer_properties::PeerPropertiesResponse, publish_confirm::PublishConfirm,
         publish_error::PublishErrorResponse, query_offset::QueryOffsetResponse,
         query_publisher_sequence::QueryPublisherResponse, sasl_handshake::SaslHandshakeResponse,
-        tune::TunesCommand,
+        superstream_partitions::SuperStreamPartitionsResponse,
+        superstream_route::SuperStreamRouteResponse, tune::TunesCommand,
     },
     error::DecodeError,
     protocol::commands::*,
     types::Header,
 };
+
 mod shims;
 
 #[cfg_attr(test, derive(fake::Dummy))]
@@ -68,6 +70,8 @@ pub enum ResponseKind {
     QueryPublisherSequence(QueryPublisherResponse),
     Credit(CreditResponse),
     ExchangeCommandVersions(ExchangeCommandVersionsResponse),
+    SuperStreamPartitions(SuperStreamPartitionsResponse),
+    SuperStreamRoute(SuperStreamRouteResponse),
 }
 
 impl Response {
@@ -96,6 +100,12 @@ impl Response {
             ResponseKind::Credit(_) => None,
             ResponseKind::ExchangeCommandVersions(exchange_command_versions) => {
                 Some(exchange_command_versions.correlation_id)
+            }
+            ResponseKind::SuperStreamPartitions(super_stream_partitions_command) => {
+                Some(super_stream_partitions_command.correlation_id)
+            }
+            ResponseKind::SuperStreamRoute(super_stream_route_command) => {
+                Some(super_stream_route_command.correlation_id)
             }
         }
     }
@@ -174,6 +184,10 @@ impl Decoder for Response {
                 .map(|(remaining, kind)| {
                     (remaining, ResponseKind::ExchangeCommandVersions(kind))
                 })?,
+            COMMAND_PARTITIONS => SuperStreamPartitionsResponse::decode(input)
+                .map(|(remaining, kind)| (remaining, ResponseKind::SuperStreamPartitions(kind)))?,
+            COMMAND_ROUTE => SuperStreamRouteResponse::decode(input)
+                .map(|(remaining, kind)| (remaining, ResponseKind::SuperStreamRoute(kind)))?,
             n => return Err(DecodeError::UnsupportedResponseType(n)),
         };
         Ok((input, Response { header, kind }))
@@ -201,6 +215,7 @@ mod tests {
 
     use byteorder::{BigEndian, WriteBytesExt};
 
+    use super::{Response, ResponseKind};
     use crate::{
         codec::{Decoder, Encoder},
         commands::{
@@ -211,14 +226,16 @@ mod tests {
             peer_properties::PeerPropertiesResponse, publish_confirm::PublishConfirm,
             publish_error::PublishErrorResponse, query_offset::QueryOffsetResponse,
             query_publisher_sequence::QueryPublisherResponse,
-            sasl_handshake::SaslHandshakeResponse, tune::TunesCommand,
+            sasl_handshake::SaslHandshakeResponse,
+            superstream_partitions::SuperStreamPartitionsResponse,
+            superstream_route::SuperStreamRouteResponse, tune::TunesCommand,
         },
         protocol::{
             commands::{
                 COMMAND_CLOSE, COMMAND_DELIVER, COMMAND_HEARTBEAT, COMMAND_METADATA,
-                COMMAND_METADATA_UPDATE, COMMAND_OPEN, COMMAND_PEER_PROPERTIES,
+                COMMAND_METADATA_UPDATE, COMMAND_OPEN, COMMAND_PARTITIONS, COMMAND_PEER_PROPERTIES,
                 COMMAND_PUBLISH_CONFIRM, COMMAND_PUBLISH_ERROR, COMMAND_QUERY_OFFSET,
-                COMMAND_QUERY_PUBLISHER_SEQUENCE, COMMAND_SASL_AUTHENTICATE,
+                COMMAND_QUERY_PUBLISHER_SEQUENCE, COMMAND_ROUTE, COMMAND_SASL_AUTHENTICATE,
                 COMMAND_SASL_HANDSHAKE, COMMAND_TUNE,
             },
             version::PROTOCOL_VERSION,
@@ -227,8 +244,6 @@ mod tests {
         types::Header,
         ResponseCode,
     };
-
-    use super::{Response, ResponseKind};
     impl Encoder for ResponseKind {
         fn encoded_size(&self) -> u32 {
             match self {
@@ -251,6 +266,12 @@ mod tests {
                 ResponseKind::Credit(credit) => credit.encoded_size(),
                 ResponseKind::ExchangeCommandVersions(exchange_command_versions) => {
                     exchange_command_versions.encoded_size()
+                }
+                ResponseKind::SuperStreamPartitions(super_stream_response) => {
+                    super_stream_response.encoded_size()
+                }
+                ResponseKind::SuperStreamRoute(super_stream_response) => {
+                    super_stream_response.encoded_size()
                 }
             }
         }
@@ -279,6 +300,12 @@ mod tests {
                 ResponseKind::Credit(credit) => credit.encode(writer),
                 ResponseKind::ExchangeCommandVersions(exchange_command_versions) => {
                     exchange_command_versions.encode(writer)
+                }
+                ResponseKind::SuperStreamPartitions(super_stream_command_versions) => {
+                    super_stream_command_versions.encode(writer)
+                }
+                ResponseKind::SuperStreamRoute(super_stream_command_versions) => {
+                    super_stream_command_versions.encode(writer)
                 }
             }
         }
@@ -447,6 +474,24 @@ mod tests {
             ExchangeCommandVersionsResponse,
             ResponseKind::ExchangeCommandVersions,
             COMMAND_EXCHANGE_COMMAND_VERSIONS
+        );
+    }
+
+    #[test]
+    fn super_stream_partitions_response_test() {
+        response_test!(
+            SuperStreamPartitionsResponse,
+            ResponseKind::SuperStreamPartitions,
+            COMMAND_PARTITIONS
+        );
+    }
+
+    #[test]
+    fn super_stream_route_response_test() {
+        response_test!(
+            SuperStreamRouteResponse,
+            ResponseKind::SuperStreamRoute,
+            COMMAND_ROUTE
         );
     }
 }

--- a/protocol/src/response/mod.rs
+++ b/protocol/src/response/mod.rs
@@ -139,6 +139,8 @@ impl Decoder for Response {
             | COMMAND_SUBSCRIBE
             | COMMAND_UNSUBSCRIBE
             | COMMAND_CREATE_STREAM
+            | COMMAND_CREATE_SUPER_STREAM
+            | COMMAND_DELETE_SUPER_STREAM
             | COMMAND_DELETE_STREAM => {
                 GenericResponse::decode(input).map(|(i, kind)| (i, ResponseKind::Generic(kind)))?
             }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -61,7 +61,9 @@ use rabbitmq_stream_protocol::{
         store_offset::StoreOffset,
         subscribe::{OffsetSpecification, SubscribeCommand},
         tune::TunesCommand,
-        unsubscribe::UnSubscribeCommand,
+        unsubscribe::UnSubscribeCommand, superstream_partitions::SuperStreamPartitionsResponse,
+        superstream_partitions::SuperStreamPartitionsRequest, superstream_route::SuperStreamRouteRequest,
+        superstream_route::SuperStreamRouteResponse,
     },
     types::PublishedMessage,
     FromResponse, Request, Response, ResponseCode, ResponseKind,
@@ -295,6 +297,20 @@ impl Client {
             UnSubscribeCommand::new(correlation_id, subscription_id)
         })
         .await
+    }
+
+    pub async fn partitions(&self, super_stream: String) -> RabbitMQStreamResult<SuperStreamPartitionsResponse> {
+        self.send_and_receive(|correlation_id| {
+            SuperStreamPartitionsRequest::new(correlation_id, super_stream)
+        })
+            .await
+    }
+
+    pub async fn route(&self, routing_key: String, super_stream: String) -> RabbitMQStreamResult<SuperStreamRouteResponse> {
+        self.send_and_receive(|correlation_id| {
+            SuperStreamRouteRequest::new(correlation_id, routing_key, super_stream)
+        })
+            .await
     }
 
     pub async fn create_stream(

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -60,10 +60,12 @@ use rabbitmq_stream_protocol::{
         sasl_handshake::{SaslHandshakeCommand, SaslHandshakeResponse},
         store_offset::StoreOffset,
         subscribe::{OffsetSpecification, SubscribeCommand},
-        tune::TunesCommand,
-        unsubscribe::UnSubscribeCommand, superstream_partitions::SuperStreamPartitionsResponse,
-        superstream_partitions::SuperStreamPartitionsRequest, superstream_route::SuperStreamRouteRequest,
+        superstream_partitions::SuperStreamPartitionsRequest,
+        superstream_partitions::SuperStreamPartitionsResponse,
+        superstream_route::SuperStreamRouteRequest,
         superstream_route::SuperStreamRouteResponse,
+        tune::TunesCommand,
+        unsubscribe::UnSubscribeCommand,
     },
     types::PublishedMessage,
     FromResponse, Request, Response, ResponseCode, ResponseKind,
@@ -299,18 +301,25 @@ impl Client {
         .await
     }
 
-    pub async fn partitions(&self, super_stream: String) -> RabbitMQStreamResult<SuperStreamPartitionsResponse> {
+    pub async fn partitions(
+        &self,
+        super_stream: String,
+    ) -> RabbitMQStreamResult<SuperStreamPartitionsResponse> {
         self.send_and_receive(|correlation_id| {
             SuperStreamPartitionsRequest::new(correlation_id, super_stream)
         })
-            .await
+        .await
     }
 
-    pub async fn route(&self, routing_key: String, super_stream: String) -> RabbitMQStreamResult<SuperStreamRouteResponse> {
+    pub async fn route(
+        &self,
+        routing_key: String,
+        super_stream: String,
+    ) -> RabbitMQStreamResult<SuperStreamRouteResponse> {
         self.send_and_receive(|correlation_id| {
             SuperStreamRouteRequest::new(correlation_id, routing_key, super_stream)
         })
-            .await
+        .await
     }
 
     pub async fn create_stream(

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -77,6 +77,21 @@ impl Environment {
             })
         }
     }
+
+    pub async fn delete_super_stream(&self, super_stream: &str) -> Result<(), StreamDeleteError> {
+        let client = self.create_client().await?;
+        let response = client.delete_super_stream(super_stream).await?;
+        client.close().await?;
+
+        if response.is_ok() {
+            Ok(())
+        } else {
+            Err(StreamDeleteError::Delete {
+                stream: super_stream.to_owned(),
+                status: response.code().clone(),
+            })
+        }
+    }
 }
 
 /// Builder for [`Environment`]

--- a/tests/integration/client_test.rs
+++ b/tests/integration/client_test.rs
@@ -41,6 +41,39 @@ async fn client_create_stream_error_test() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn client_create_and_delete_super_stream_test() {
+    let super_stream_name = "test-super-stream";
+
+    let client = Client::connect(ClientOptions::default()).await.unwrap();
+
+    let partitions: Vec<String> = [
+        "test-super-stream-0",
+        "test-super-stream-1",
+        "test-super-stream-2",
+    ]
+    .iter()
+    .map(|&x| x.into())
+    .collect();
+
+    let binding_keys: Vec<String> = ["0", "1", "2"].iter().map(|&x| x.into()).collect();
+
+    let response = client
+        .create_super_stream(&super_stream_name, partitions, binding_keys, HashMap::new())
+        .await
+        .unwrap();
+
+    assert_eq!(&ResponseCode::Ok, response.code());
+
+    let response = client
+        .delete_super_stream(&super_stream_name)
+        .await
+        .unwrap();
+
+    assert_eq!(&ResponseCode::Ok, response.code());
+
+    let _ = client.close().await;
+}
+
 async fn client_delete_stream_test() {
     let test = TestClient::create().await;
 

--- a/tests/integration/client_test.rs
+++ b/tests/integration/client_test.rs
@@ -73,7 +73,49 @@ async fn client_create_and_delete_super_stream_test() {
 
     let _ = client.close().await;
 }
+#[tokio::test(flavor = "multi_thread")]
+async fn client_create_super_stream_error_test() {
+    let super_stream_name = "test-super-stream-error";
 
+    let client = Client::connect(ClientOptions::default()).await.unwrap();
+
+    let partitions: Vec<String> = [
+        "test-super-stream-error-0",
+        "test-super-stream-error-1",
+        "test-super-stream-error-2",
+    ]
+    .iter()
+    .map(|&x| x.into())
+    .collect();
+
+    let binding_keys: Vec<String> = ["0", "1", "2"].iter().map(|&x| x.into()).collect();
+
+    let response = client
+        .create_super_stream(
+            &super_stream_name,
+            partitions.clone(),
+            binding_keys.clone(),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(&ResponseCode::Ok, response.code());
+
+    let response = client
+        .create_super_stream(&super_stream_name, partitions, binding_keys, HashMap::new())
+        .await
+        .unwrap();
+
+    assert_eq!(&ResponseCode::StreamAlreadyExists, response.code());
+
+    let response = client
+        .delete_super_stream(&super_stream_name)
+        .await
+        .unwrap();
+
+    assert_eq!(&ResponseCode::Ok, response.code());
+}
 async fn client_delete_stream_test() {
     let test = TestClient::create().await;
 

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -7,6 +7,8 @@ use rabbitmq_stream_protocol::ResponseCode;
 pub struct TestClient {
     pub client: Client,
     pub stream: String,
+    pub super_stream: String,
+    pub partitions: Vec<String>,
 }
 
 pub struct TestEnvironment {
@@ -22,16 +24,67 @@ impl TestClient {
         let response = client.create_stream(&stream, HashMap::new()).await.unwrap();
 
         assert_eq!(&ResponseCode::Ok, response.code());
-        TestClient { client, stream }
+        TestClient {
+            client,
+            stream,
+            super_stream: String::new(),
+            partitions: Vec::new(),
+        }
+    }
+
+    pub async fn create_super_stream() -> TestClient {
+        let super_stream: String = Faker.fake();
+        let client = Client::connect(ClientOptions::default()).await.unwrap();
+
+        let partitions: Vec<String> = [
+            super_stream.to_string() + "-0",
+            super_stream.to_string() + "-1",
+            super_stream.to_string() + "-2",
+        ]
+        .iter()
+        .map(|x| x.into())
+        .collect();
+
+        let binding_keys: Vec<String> = ["0", "1", "2"].iter().map(|&x| x.into()).collect();
+
+        let response = client
+            .create_super_stream(
+                &super_stream,
+                partitions.clone(),
+                binding_keys,
+                HashMap::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(&ResponseCode::Ok, response.code());
+        TestClient {
+            client,
+            stream: String::new(),
+            super_stream,
+            partitions,
+        }
     }
 }
 
 impl Drop for TestClient {
     fn drop(&mut self) {
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current()
-                .block_on(async { self.client.delete_stream(&self.stream).await.unwrap() })
-        });
+        if self.stream != "" {
+            tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current()
+                    .block_on(async { self.client.delete_stream(&self.stream).await.unwrap() })
+            });
+        }
+        if self.super_stream != "" {
+            tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async {
+                    self.client
+                        .delete_super_stream(&self.super_stream)
+                        .await
+                        .unwrap()
+                })
+            });
+        }
     }
 }
 

--- a/tests/integration/environment_test.rs
+++ b/tests/integration/environment_test.rs
@@ -14,6 +14,24 @@ async fn environment_create_test() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn environment_create_and_delete_super_stream_test() {
+    let super_stream = "super_stream_test";
+    let env = Environment::builder().build().await.unwrap();
+
+    let response = env
+        .stream_creator()
+        .max_length(ByteCapacity::GB(5))
+        .create_super_stream(super_stream, 3, None)
+        .await;
+
+    assert_eq!(response.is_ok(), true);
+
+    let response = env.delete_super_stream(super_stream).await;
+
+    assert_eq!(response.is_ok(), true);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn environment_fail_to_connect_wrong_config() {
     // test the wrong config
     // the client should fail to connect


### PR DESCRIPTION
This closes #9 
This closes #8 

This PR is a first step for super_stream implementation.

It implements:

- CREATE/DELETE super_stream commands
- PARTITIONS AND ROUTE commands

Integrate the commands in the Client