### PR TITLE
close client connection in client consumer

### DIFF
--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -120,6 +120,7 @@ impl ConsumerBuilder {
                         }
                     }
                 } else {
+                    client.close().await?;
                     client = Client::connect(ClientOptions {
                         host: replica.host.clone(),
                         port: replica.port as u16,
@@ -267,6 +268,7 @@ impl ConsumerHandle {
                 let response = self.0.client.unsubscribe(self.0.subscription_id).await?;
                 if response.is_ok() {
                     self.0.waker.wake();
+                    self.0.client.close().await?;
                     Ok(())
                 } else {
                     Err(ConsumerCloseError::Close {


### PR DESCRIPTION
I think in the Consumer part we create a client on line 97 which creates a connection:

```
 let mut client = self.environment.create_client().await?;
```

But then we create another one on line 123 without closing the previous one:

```
client = Client::connect(ClientOptions ....
```

Also in the close handle we don't close the locator connection.

This PR should solve the issue