### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 
 [dependencies]
 tokio-rustls = {version="0.24.1", features=["dangerous_configuration"]}
-rustls-pemfile = "1.0.3"
+rustls-pemfile = "1.0.4"
 rabbitmq-stream-protocol = { version = "0.6", path = "protocol" }
 tokio = { version = "1.29.1", features = ["full"] }
 tokio-util = { version = "0.7.3", features = ["codec"] }
@@ -35,10 +35,10 @@ tracing = "0.1"
 thiserror = "1.0"
 async-trait = "0.1.51"
 rand = "0.8"
-dashmap = "5.3.4"
+dashmap = "6.1.0"
 murmur3 = "0.5.2"
 
 [dev-dependencies]
 tracing-subscriber = "0.3.1"
-fake = { version = "2.4", features = ['derive'] }
+fake = { version = "3.0.0", features = ['derive'] }
 chrono = "0.4.26"


### PR DESCRIPTION
Update dependencies.

`tokio-rustls`  and `rustls-pemfile`  can't be updated to the last version. There are some breaking changes. 
We will prepare another pr. 