### PR TITLE
Moving producers/consumers client connection creation to Environment

### DIFF
--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -132,12 +132,10 @@ impl ConsumerBuilder {
 
         let collector = self.environment.options.client_options.collector.clone();
 
-        let client_uwrapped = self
+        let client = self
             .environment
             .create_consumer_client(stream, self.client_provided_name.clone())
             .await?;
-
-        let client = client_uwrapped.clone();
 
         let subscription_id = 1;
         let (tx, rx) = channel(10000);

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -26,11 +26,9 @@ use crate::error::ConsumerStoreOffsetError;
 use crate::{
     client::{MessageHandler, MessageResult},
     error::{ConsumerCloseError, ConsumerCreateError, ConsumerDeliveryError},
-    Client, ClientOptions, Environment, MetricsCollector,
+    Client, Environment, MetricsCollector,
 };
 use futures::{future::BoxFuture, task::AtomicWaker, Stream};
-use rand::rngs::StdRng;
-use rand::{seq::SliceRandom, SeedableRng};
 
 type FilterPredicate = Option<Arc<dyn Fn(&Message) -> bool + Send + Sync>>;
 
@@ -132,56 +130,14 @@ impl ConsumerBuilder {
             return Err(ConsumerCreateError::SingleActiveConsumerNotSupported);
         }
 
-        // Connect to the user specified node first, then look for a random replica to connect to instead.
-        // This is recommended for load balancing purposes
-        let mut opt_with_client_provided_name = self.environment.options.client_options.clone();
-        opt_with_client_provided_name.client_provided_name = self.client_provided_name.clone();
-
-        let mut client = self
-            .environment
-            .create_client_with_options(opt_with_client_provided_name)
-            .await?;
         let collector = self.environment.options.client_options.collector.clone();
-        if let Some(metadata) = client.metadata(vec![stream.to_string()]).await?.get(stream) {
-            // If there are no replicas we do not reassign client, meaning we just keep reading from the leader.
-            // This is desired behavior in case there is only one node in the cluster.
-            if let Some(replica) = metadata.replicas.choose(&mut StdRng::from_entropy()) {
-                tracing::debug!(
-                    "Picked replica {:?} out of possible candidates {:?} for stream {}",
-                    replica,
-                    metadata.replicas,
-                    stream
-                );
-                let load_balancer_mode = self.environment.options.client_options.load_balancer_mode;
-                if load_balancer_mode {
-                    let options = self.environment.options.client_options.clone();
-                    loop {
-                        let temp_client = Client::connect(options.clone()).await?;
-                        let mapping = temp_client.connection_properties().await;
-                        if let Some(advertised_host) = mapping.get("advertised_host") {
-                            if *advertised_host == replica.host.clone() {
-                                client.close().await?;
-                                client = temp_client;
-                                break;
-                            }
-                        }
-                        temp_client.close().await?;
-                    }
-                } else {
-                    client.close().await?;
-                    client = Client::connect(ClientOptions {
-                        host: replica.host.clone(),
-                        port: replica.port as u16,
-                        ..self.environment.options.client_options
-                    })
-                    .await?;
-                }
-            }
-        } else {
-            return Err(ConsumerCreateError::StreamDoesNotExist {
-                stream: stream.into(),
-            });
-        }
+
+        let client_uwrapped = self
+            .environment
+            .create_consumer_client(stream, self.client_provided_name.clone())
+            .await?;
+
+        let client = client_uwrapped.clone();
 
         let subscription_id = 1;
         let (tx, rx) = channel(10000);

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -39,7 +39,7 @@ impl Environment {
         Ok(Environment { options })
     }
 
-    pub async fn create_producer_client(
+    pub(crate) async fn create_producer_client(
         self,
         stream: &str,
         client_provided_name: String,
@@ -91,7 +91,7 @@ impl Environment {
         Ok(client)
     }
 
-    pub async fn create_consumer_client(
+    pub(crate) async fn create_consumer_client(
         self,
         stream: &str,
         client_provided_name: String,

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -4,12 +4,15 @@ use std::time::Duration;
 
 use crate::producer::NoDedup;
 use crate::types::OffsetSpecification;
+use rand::prelude::SliceRandom;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 use std::collections::HashMap;
 
 use crate::{
     client::{Client, ClientOptions, MetricsCollector},
     consumer::ConsumerBuilder,
-    error::StreamDeleteError,
+    error::{ConsumerCreateError, ProducerCreateError, StreamDeleteError},
     producer::ProducerBuilder,
     stream_creator::StreamCreator,
     superstream::RoutingStrategy,
@@ -34,6 +37,114 @@ impl Environment {
         let client = Client::connect(options.client_options.clone()).await?;
         client.close().await?;
         Ok(Environment { options })
+    }
+
+    pub async fn create_producer_client(
+        self,
+        stream: &str,
+        client_provided_name: String,
+    ) -> Result<Client, ProducerCreateError> {
+        let mut opt_with_client_provided_name = self.options.client_options.clone();
+        opt_with_client_provided_name.client_provided_name = client_provided_name.clone();
+
+        let mut client = self
+            .create_client_with_options(opt_with_client_provided_name.clone())
+            .await?;
+
+        if let Some(metadata) = client.metadata(vec![stream.to_string()]).await?.get(stream) {
+            tracing::debug!(
+                "Connecting to leader node {:?} of stream {}",
+                metadata.leader,
+                stream
+            );
+            let load_balancer_mode = self.options.client_options.load_balancer_mode;
+            if load_balancer_mode {
+                // Producer must connect to leader node
+                let options: ClientOptions = self.options.client_options.clone();
+                loop {
+                    let temp_client = Client::connect(options.clone()).await?;
+                    let mapping = temp_client.connection_properties().await;
+                    if let Some(advertised_host) = mapping.get("advertised_host") {
+                        if *advertised_host == metadata.leader.host.clone() {
+                            client.close().await?;
+                            client = temp_client;
+                            break;
+                        }
+                    }
+                    temp_client.close().await?;
+                }
+            } else {
+                client.close().await?;
+                client = Client::connect(ClientOptions {
+                    host: metadata.leader.host.clone(),
+                    port: metadata.leader.port as u16,
+                    ..opt_with_client_provided_name.clone()
+                })
+                .await?
+            };
+        } else {
+            return Err(ProducerCreateError::StreamDoesNotExist {
+                stream: stream.into(),
+            });
+        }
+
+        Ok(client)
+    }
+
+    pub async fn create_consumer_client(
+        self,
+        stream: &str,
+        client_provided_name: String,
+    ) -> Result<Client, ConsumerCreateError> {
+        let mut opt_with_client_provided_name = self.options.client_options.clone();
+        opt_with_client_provided_name.client_provided_name = client_provided_name.clone();
+
+        let mut client = self
+            .create_client_with_options(opt_with_client_provided_name.clone())
+            .await?;
+
+        if let Some(metadata) = client.metadata(vec![stream.to_string()]).await?.get(stream) {
+            // If there are no replicas we do not reassign client, meaning we just keep reading from the leader.
+            // This is desired behavior in case there is only one node in the cluster.
+            if let Some(replica) = metadata.replicas.choose(&mut StdRng::from_entropy()) {
+                tracing::debug!(
+                    "Picked replica {:?} out of possible candidates {:?} for stream {}",
+                    replica,
+                    metadata.replicas,
+                    stream
+                );
+                let load_balancer_mode = self.options.client_options.load_balancer_mode;
+                if load_balancer_mode {
+                    let options = self.options.client_options.clone();
+                    loop {
+                        let temp_client = Client::connect(options.clone()).await?;
+                        let mapping = temp_client.connection_properties().await;
+                        if let Some(advertised_host) = mapping.get("advertised_host") {
+                            if *advertised_host == replica.host.clone() {
+                                client.close().await?;
+                                client = temp_client;
+                                break;
+                            }
+                        }
+                        temp_client.close().await?;
+                    }
+                } else {
+                    client.close().await?;
+                    client = Client::connect(ClientOptions {
+                        host: replica.host.clone(),
+                        port: replica.port as u16,
+                        ..self.options.client_options
+                    })
+                    .await?;
+                }
+            }
+        } else {
+            return Err(ConsumerCreateError::StreamDoesNotExist {
+                stream: stream.into(),
+            });
+        }
+
+        Ok(client)
     }
 
     /// Returns a builder for creating a stream with a specific configuration

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -120,12 +120,10 @@ impl<T> ProducerBuilder<T> {
 
         let metrics_collector = self.environment.options.client_options.collector.clone();
 
-        let client_unwrapped = self
+        let client = self
             .environment
             .create_producer_client(stream, self.client_provided_name.clone())
             .await?;
-
-        let client = client_unwrapped;
 
         let mut publish_version = 1;
 


### PR DESCRIPTION
Moving client connection creation from Producers/Consumers to Environment could help a better management of the disconnection in the future as this methods need to be called eventually to reconnect