### PR TITLE
Expose SuperStreamProducer struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,16 @@ murmur3 = "0.5.2"
 tracing-subscriber = "0.3.1"
 fake = { version = "3.0.0", features = ['derive'] }
 chrono = "0.4.26"
+
+[[example]]
+name="receive_super_stream"
+path="examples/superstreams/receive_super_stream.rs"
+[[example]]
+name="send_super_stream_hash"
+path="examples/superstreams/send_super_stream_hash.rs"
+[[example]]
+name="send_super_stream_routing_key"
+path="examples/superstreams/send_super_stream_routing_key.rs"
+[[example]]
+name="send_super_stream"
+path="examples/superstreams/send_super_stream.rs"

--- a/examples/batch_send.rs
+++ b/examples/batch_send.rs
@@ -1,4 +1,3 @@
-use futures::StreamExt;
 use rabbitmq_stream_client::{
     types::{ByteCapacity, Message},
     Environment,

--- a/examples/environment.rs
+++ b/examples/environment.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .create("test")
         .await?;
 
-    let mut producer = environment
+    let producer = environment
         .producer()
         .client_provided_name("my producer")
         .build("test")

--- a/examples/superstreams/send_super_stream_hash.rs
+++ b/examples/superstreams/send_super_stream_hash.rs
@@ -1,7 +1,9 @@
 use rabbitmq_stream_client::error::StreamCreateError;
 use rabbitmq_stream_client::types::{
     ByteCapacity, HashRoutingMurmurStrategy, Message, ResponseCode, RoutingStrategy,
+    SuperStreamProducer,
 };
+use rabbitmq_stream_client::NoDedup;
 use std::convert::TryInto;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
@@ -67,7 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Super stream example. Sending {} messages to the super stream: {}",
         message_count, super_stream
     );
-    let mut super_stream_producer = environment
+    let mut super_stream_producer: SuperStreamProducer<NoDedup> = environment
         .super_stream_producer(RoutingStrategy::HashRoutingStrategy(
             HashRoutingMurmurStrategy {
                 routing_extractor: &hash_strategy_value_extractor,

--- a/examples/superstreams/send_super_stream_routing_key.rs
+++ b/examples/superstreams/send_super_stream_routing_key.rs
@@ -1,6 +1,6 @@
 use rabbitmq_stream_client::error::StreamCreateError;
 use rabbitmq_stream_client::types::{
-    ByteCapacity, RoutingKeyRoutingStrategy, Message, ResponseCode, RoutingStrategy,
+    ByteCapacity, Message, ResponseCode, RoutingKeyRoutingStrategy, RoutingStrategy,
 };
 use std::convert::TryInto;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -83,14 +83,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let counter = confirmed_messages.clone();
         let notifier = notify_on_send.clone();
         // Region names are the same as the binding_keys we specified during superstream creation
-        let mut region = "";
-        if i % 3 == 0   {
-            region = "EMEA"
-        } else if i % 3 == 1   {
-            region = "APAC"
-        }  else  {
-            region = "AMER"
-        }
+        let region = if i % 3 == 0 {
+            "EMEA"
+        } else if i % 3 == 1 {
+            "APAC"
+        } else {
+            "AMER"
+        };
 
         let msg = Message::builder()
             .body(format!("super stream message_{}", i))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@ pub mod types {
     pub use crate::superstream::RoutingKeyRoutingStrategy;
     pub use crate::superstream::RoutingStrategy;
     pub use crate::superstream_consumer::SuperStreamConsumer;
+    pub use crate::superstream_producer::SuperStreamProducer;
     pub use rabbitmq_stream_protocol::message::Message;
     pub use rabbitmq_stream_protocol::{Response, ResponseCode, ResponseKind};
 

--- a/src/superstream.rs
+++ b/src/superstream.rs
@@ -37,9 +37,11 @@ impl DefaultSuperStreamMetadata {
     }
 }
 
+type RoutingExtractor = dyn Fn(&Message) -> String + 'static + Sync + Send;
+
 #[derive(Clone)]
 pub struct RoutingKeyRoutingStrategy {
-    pub routing_extractor: &'static dyn Fn(&Message) -> String,
+    pub routing_extractor: &'static RoutingExtractor,
 }
 
 impl RoutingKeyRoutingStrategy {
@@ -56,7 +58,7 @@ impl RoutingKeyRoutingStrategy {
 
 #[derive(Clone)]
 pub struct HashRoutingMurmurStrategy {
-    pub routing_extractor: &'static dyn Fn(&Message) -> String,
+    pub routing_extractor: &'static RoutingExtractor,
 }
 
 impl HashRoutingMurmurStrategy {
@@ -85,4 +87,17 @@ impl HashRoutingMurmurStrategy {
 pub enum RoutingStrategy {
     HashRoutingStrategy(HashRoutingMurmurStrategy),
     RoutingKeyStrategy(RoutingKeyRoutingStrategy),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<RoutingStrategy>();
+        assert_send_sync::<HashRoutingMurmurStrategy>();
+        assert_send_sync::<RoutingKeyRoutingStrategy>();
+    }
 }

--- a/src/superstream_consumer.rs
+++ b/src/superstream_consumer.rs
@@ -208,3 +208,14 @@ impl SuperStreamConsumerHandle {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<SuperStreamConsumer>();
+    }
+}

--- a/src/superstream_producer.rs
+++ b/src/superstream_producer.rs
@@ -158,3 +158,18 @@ impl<T> SuperStreamProducerBuilder<T> {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Dedup;
+
+    use super::*;
+
+    #[test]
+    fn test_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<SuperStreamProducer<NoDedup>>();
+        assert_send_sync::<SuperStreamProducer<Dedup>>();
+    }
+}


### PR DESCRIPTION
I notice the struct `SuperStreamProducer` is not exposed as `SuperStreamConsumer`. Even if it compiles, I cannot create a function that accepts or returns that type. This PR:
- expose `SuperStreamProducer`
- define `examples` under `examples/superstreams` that rust ignores.
- fix some clippy issues in examples/superstreams folder
- `RoutingStrategy` implements send + sync so also `SuperStreamProducer` implements send + sync