### PR TITLE
Deserialize `ClientOption` with serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,10 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 tracing-subscriber = "0.3.1"
 fake = { version = "3.0.0", features = ['derive'] }
 chrono = "0.4.26"
+serde_json = "1.0"
 
 [features]
-default = ["serde"]
+default = []
 serde = ["dep:serde"]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ chrono = "0.4.26"
 serde_json = "1.0"
 
 [features]
-default = []
+default = ["serde"]
 serde = ["dep:serde"]
 
 [[example]]
@@ -61,3 +61,7 @@ path="examples/superstreams/send_super_stream_routing_key.rs"
 [[example]]
 name="send_super_stream"
 path="examples/superstreams/send_super_stream.rs"
+[[example]]
+name="environment_deserialization"
+path="examples/environment_deserialization.rs"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ keywords = ["AMQP", "IoT", "messaging", "streams"]
 categories = ["network-programming"]
 readme = "README.md"
 
-
+[package.metadata."docs.rs"]
+all-features = true
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,16 @@ async-trait = "0.1.51"
 rand = "0.8"
 dashmap = "6.1.0"
 murmur3 = "0.5.2"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 tracing-subscriber = "0.3.1"
 fake = { version = "3.0.0", features = ['derive'] }
 chrono = "0.4.26"
+
+[features]
+default = ["serde"]
+serde = ["dep:serde"]
 
 [[example]]
 name="receive_super_stream"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ chrono = "0.4.26"
 serde_json = "1.0"
 
 [features]
-default = ["serde"]
+default = []
 serde = ["dep:serde"]
 
 [[example]]

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,14 @@ fmt:
 	cargo fmt --all -- --check
 
 clippy:
-	cargo clippy --all -- -D warnings
+	cargo clippy --all --all-features -- -D warnings
 
 build: fmt clippy
+	cargo build --all-features
 	cargo build
 
 test: build
-	cargo test --all -- --nocapture
+	cargo test --all --all-features -- --nocapture
 
 watch: build
 	cargo watch -x 'test --all -- --nocapture'

--- a/examples/environment_deserialization.rs
+++ b/examples/environment_deserialization.rs
@@ -1,0 +1,116 @@
+#[cfg(feature = "serde")]
+mod example {
+    use tracing::{info, Level};
+    use tracing_subscriber::FmtSubscriber;
+
+    use futures::StreamExt;
+    use rabbitmq_stream_client::{
+        types::{ByteCapacity, Message, OffsetSpecification},
+        ClientOptions, Environment,
+    };
+    use serde::*;
+
+    #[derive(Deserialize)]
+    struct QueueConfig {
+        #[serde(flatten)]
+        rabbitmq: ClientOptions,
+        stream_name: String,
+        capabity: ByteCapacity,
+        producer_client_name: String,
+        consumer_client_name: String,
+    }
+
+    #[derive(Deserialize)]
+    struct MyConfig {
+        queue_config: QueueConfig,
+    }
+
+    pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
+        let subscriber = FmtSubscriber::builder()
+            .with_max_level(Level::TRACE)
+            .finish();
+
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("setting default subscriber failed");
+
+        // The configuration is loadable from a file.
+        // Here, just for semplification, we use a JSON string.
+        // NB: we use `serde` internally, so you can use any format supported by serde.
+        let j = r#"
+{
+    "queue_config": {
+        "host": "localhost",
+        "tls": {
+            "enabled": false
+        },
+        "stream_name": "test",
+        "capabity": "5GB",
+        "producer_client_name": "producer",
+        "consumer_client_name": "consumer"
+    }
+}
+        "#;
+        let my_config: MyConfig = serde_json::from_str(j).unwrap();
+        let environment = Environment::from_client_option(my_config.queue_config.rabbitmq).await?;
+
+        let message_count = 10;
+        environment
+            .stream_creator()
+            .max_length(my_config.queue_config.capabity)
+            .create(&my_config.queue_config.stream_name)
+            .await?;
+
+        let producer = environment
+            .producer()
+            .client_provided_name(&my_config.queue_config.producer_client_name)
+            .build(&my_config.queue_config.stream_name)
+            .await?;
+
+        for i in 0..message_count {
+            producer
+                .send_with_confirm(Message::builder().body(format!("message{}", i)).build())
+                .await?;
+        }
+
+        producer.close().await?;
+
+        let mut consumer = environment
+            .consumer()
+            .client_provided_name(&my_config.queue_config.consumer_client_name)
+            .offset(OffsetSpecification::First)
+            .build(&my_config.queue_config.stream_name)
+            .await
+            .unwrap();
+
+        for _ in 0..message_count {
+            let delivery = consumer.next().await.unwrap()?;
+            info!(
+                "Got message : {:?} with offset {}",
+                delivery
+                    .message()
+                    .data()
+                    .map(|data| String::from_utf8(data.to_vec())),
+                delivery.offset()
+            );
+        }
+
+        consumer.handle().close().await.unwrap();
+
+        environment.delete_stream("test").await?;
+
+        Ok(())
+    }
+}
+#[cfg(not(feature = "serde"))]
+mod example {
+    pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
+        panic!("This example requires the 'serde' feature to be enabled. Add `--features serde` to the cargo command.");
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    example::run().await?;
+
+    Ok(())
+}

--- a/examples/simple-consumer.rs
+++ b/examples/simple-consumer.rs
@@ -33,8 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .unwrap();
 
-    while let delivery = consumer.next().await.unwrap() {
-        let delivery = delivery.unwrap();
+    while let Some(Ok(delivery)) = consumer.next().await {
         println!(
             "Got message: {:#?} from stream: {} with offset: {}",
             delivery

--- a/examples/tls_producer.rs
+++ b/examples/tls_producer.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // it will start a rabbitmq server with compatible TLS certificates
     let tls_configuration: TlsConfiguration = TlsConfiguration::builder()
         .add_root_certificates(String::from(".ci/certs/ca_certificate.pem"))
-        .build();
+        .build()?;
 
     // Use this configuration if you want to trust the certificates
     // without providing the root certificate and the client certificates

--- a/src/byte_capacity.rs
+++ b/src/byte_capacity.rs
@@ -22,3 +22,113 @@ impl ByteCapacity {
         }
     }
 }
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for ByteCapacity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Visitor;
+        use std::fmt;
+
+        struct U32OrStringVisitor;
+
+        impl Visitor<'_> for U32OrStringVisitor {
+            type Value = ByteCapacity;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a u64 or a \\d+(B|KB|MB|GB|TB) string")
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(ByteCapacity::B(v))
+            }
+
+            fn visit_str<E>(self, str: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if str.ends_with("TB") {
+                    let num = str
+                        .trim_end_matches("TB")
+                        .parse()
+                        .map_err(serde::de::Error::custom)?;
+                    Ok(ByteCapacity::TB(num))
+                } else if str.ends_with("GB") {
+                    let num = str
+                        .trim_end_matches("GB")
+                        .parse()
+                        .map_err(serde::de::Error::custom)?;
+                    Ok(ByteCapacity::GB(num))
+                } else if str.ends_with("MB") {
+                    let num = str
+                        .trim_end_matches("MB")
+                        .parse()
+                        .map_err(serde::de::Error::custom)?;
+                    Ok(ByteCapacity::MB(num))
+                } else if str.ends_with("KB") {
+                    let num = str
+                        .trim_end_matches("KB")
+                        .parse()
+                        .map_err(serde::de::Error::custom)?;
+                    Ok(ByteCapacity::KB(num))
+                } else if str.ends_with("B") {
+                    let num = str
+                        .trim_end_matches("B")
+                        .parse()
+                        .map_err(serde::de::Error::custom)?;
+                    Ok(ByteCapacity::B(num))
+                } else {
+                    let num = str.parse().map_err(serde::de::Error::custom)?;
+                    Ok(ByteCapacity::B(num))
+                }
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_str(&v)
+            }
+        }
+
+        deserializer.deserialize_any(U32OrStringVisitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+mod tests {
+    #[test]
+    fn test_deserilize_byte_capacity() {
+        use crate::types::ByteCapacity;
+
+        assert!(matches!(
+            serde_json::from_str::<ByteCapacity>("\"5GB\""),
+            Ok(ByteCapacity::GB(5))
+        ));
+        assert!(matches!(
+            serde_json::from_str::<ByteCapacity>("\"5TB\""),
+            Ok(ByteCapacity::TB(5))
+        ));
+        assert!(matches!(
+            serde_json::from_str::<ByteCapacity>("\"5MB\""),
+            Ok(ByteCapacity::MB(5))
+        ));
+        assert!(matches!(
+            serde_json::from_str::<ByteCapacity>("\"5KB\""),
+            Ok(ByteCapacity::KB(5))
+        ));
+        assert!(matches!(
+            serde_json::from_str::<ByteCapacity>("\"5B\""),
+            Ok(ByteCapacity::B(5))
+        ));
+        assert!(matches!(
+            serde_json::from_str::<ByteCapacity>("\"5\""),
+            Ok(ByteCapacity::B(5))
+        ));
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -37,7 +37,7 @@ use crate::{error::ClientError, RabbitMQStreamResult};
 pub use message::ClientMessage;
 pub use metadata::{Broker, StreamMetadata};
 pub use metrics::MetricsCollector;
-pub use options::ClientOptions;
+pub use options::{ClientOptions, TlsConfiguration, TlsConfigurationBuilder};
 use rabbitmq_stream_protocol::{
     commands::{
         close::{CloseRequest, CloseResponse},

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -319,40 +319,37 @@ impl TlsConfigurationBuilder {
         self
     }
 
-    pub fn add_root_certificates<T>(mut self, root_certificates_path: T) -> TlsConfigurationBuilder
+    pub fn add_root_certificates<T>(self, root_certificates_path: T) -> TlsConfigurationBuilder
     where
         T: Into<PathBuf>,
     {
-        self.root_certificates_path = Some(root_certificates_path.into());
-        self
+        let mut s = self.enable(true);
+        s.root_certificates_path = Some(root_certificates_path.into());
+        s
     }
 
     #[cfg(feature = "serde")]
-    fn add_client_certificates_path<T>(
-        mut self,
-        client_certificates_path: T,
-    ) -> TlsConfigurationBuilder
+    fn add_client_certificates_path<T>(self, client_certificates_path: T) -> TlsConfigurationBuilder
     where
         T: Into<PathBuf>,
     {
-        self.client_certificates_path = Some(client_certificates_path.into());
-        self
+        let mut s = self.enable(true);
+        s.client_certificates_path = Some(client_certificates_path.into());
+        s
     }
 
     #[cfg(feature = "serde")]
-    fn add_client_private_key_path<T>(
-        mut self,
-        client_private_key_path: T,
-    ) -> TlsConfigurationBuilder
+    fn add_client_private_key_path<T>(self, client_private_key_path: T) -> TlsConfigurationBuilder
     where
         T: Into<PathBuf>,
     {
-        self.client_private_key_path = Some(client_private_key_path.into());
-        self
+        let mut s = self.enable(true);
+        s.client_private_key_path = Some(client_private_key_path.into());
+        s
     }
 
     pub fn add_client_certificates_keys<T1, T2>(
-        mut self,
+        self,
         client_certificates_path: T1,
         client_private_key_path: T2,
     ) -> TlsConfigurationBuilder
@@ -360,9 +357,10 @@ impl TlsConfigurationBuilder {
         T1: Into<PathBuf>,
         T2: Into<PathBuf>,
     {
-        self.client_certificates_path = Some(client_certificates_path.into());
-        self.client_private_key_path = Some(client_private_key_path.into());
-        self
+        let mut s = self.enable(true);
+        s.client_certificates_path = Some(client_certificates_path.into());
+        s.client_private_key_path = Some(client_private_key_path.into());
+        s
     }
 
     pub fn build(self) -> Result<TlsConfiguration, &'static str> {

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -1,7 +1,6 @@
 use std::{fmt::Debug, sync::Arc};
 
 use super::metrics::{MetricsCollector, NopMetricsCollector};
-use crate::environment::TlsConfiguration;
 
 #[derive(Clone)]
 pub struct ClientOptions {
@@ -170,5 +169,109 @@ mod tests {
         assert_eq!(options.max_frame_size, 1);
         assert_eq!(options.tls.enabled, true);
         assert_eq!(options.load_balancer_mode, true);
+    }
+}
+
+/** Helper for tls configuration */
+#[derive(Clone)]
+pub struct TlsConfiguration {
+    pub(crate) enabled: bool,
+    pub(crate) trust_certificates: bool,
+    pub(crate) root_certificates_path: String,
+    pub(crate) client_certificates_path: String,
+    pub(crate) client_keys_path: String,
+}
+
+impl Default for TlsConfiguration {
+    fn default() -> TlsConfiguration {
+        TlsConfiguration {
+            enabled: true,
+            trust_certificates: false,
+            root_certificates_path: String::from(""),
+            client_certificates_path: String::from(""),
+            client_keys_path: String::from(""),
+        }
+    }
+}
+
+impl TlsConfiguration {
+    pub fn enable(&mut self, enabled: bool) {
+        self.enabled = enabled
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn trust_certificates(&mut self, trust_certificates: bool) {
+        self.trust_certificates = trust_certificates
+    }
+
+    pub fn trust_certificates_enabled(&self) -> bool {
+        self.trust_certificates
+    }
+
+    pub fn get_root_certificates_path(&self) -> String {
+        self.root_certificates_path.clone()
+    }
+    //
+    pub fn add_root_certificates_path(&mut self, certificate_path: String) {
+        self.root_certificates_path = certificate_path
+    }
+
+    pub fn get_client_certificates_path(&self) -> String {
+        self.client_certificates_path.clone()
+    }
+
+    pub fn get_client_keys_path(&self) -> String {
+        self.client_keys_path.clone()
+    }
+    //
+    pub fn add_client_certificates_keys(
+        &mut self,
+        certificate_path: String,
+        client_private_key_path: String,
+    ) {
+        self.client_certificates_path = certificate_path;
+        self.client_keys_path = client_private_key_path;
+    }
+}
+
+pub struct TlsConfigurationBuilder(TlsConfiguration);
+
+impl TlsConfigurationBuilder {
+    pub fn enable(mut self, enable: bool) -> TlsConfigurationBuilder {
+        self.0.enabled = enable;
+        self
+    }
+
+    pub fn trust_certificates(mut self, trust_certificates: bool) -> TlsConfigurationBuilder {
+        self.0.trust_certificates = trust_certificates;
+        self
+    }
+
+    pub fn add_root_certificates(mut self, certificate_path: String) -> TlsConfigurationBuilder {
+        self.0.root_certificates_path = certificate_path;
+        self
+    }
+
+    pub fn add_client_certificates_keys(
+        mut self,
+        certificate_path: String,
+        client_private_key_path: String,
+    ) -> TlsConfigurationBuilder {
+        self.0.client_certificates_path = certificate_path;
+        self.0.client_keys_path = client_private_key_path;
+        self
+    }
+
+    pub fn build(self) -> TlsConfiguration {
+        self.0
+    }
+}
+
+impl TlsConfiguration {
+    pub fn builder() -> TlsConfigurationBuilder {
+        TlsConfigurationBuilder(TlsConfiguration::default())
     }
 }

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -19,17 +19,29 @@ use super::{
 };
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct ClientOptions {
+    #[cfg_attr(feature = "serde", serde(default = "default_host"))]
     pub(crate) host: String,
+    #[cfg_attr(feature = "serde", serde(default = "default_port"))]
     pub(crate) port: u16,
+    #[cfg_attr(feature = "serde", serde(default = "default_user"))]
     pub(crate) user: String,
+    #[cfg_attr(feature = "serde", serde(default = "default_password"))]
     pub(crate) password: String,
+    #[cfg_attr(feature = "serde", serde(default = "default_v_host"))]
     pub(crate) v_host: String,
+    #[cfg_attr(feature = "serde", serde(default = "default_heartbeat"))]
     pub(crate) heartbeat: u32,
+    #[cfg_attr(feature = "serde", serde(default = "default_max_frame_size"))]
     pub(crate) max_frame_size: u32,
+    #[cfg_attr(feature = "serde", serde(default = "default_load_balancer_mode"))]
     pub(crate) load_balancer_mode: bool,
+    #[cfg_attr(feature = "serde", serde(default))]
     pub(crate) tls: TlsConfiguration,
+    #[cfg_attr(feature = "serde", serde(skip, default = "default_collector"))]
     pub(crate) collector: Arc<dyn MetricsCollector>,
+    #[cfg_attr(feature = "serde", serde(default = "default_client_provided_name"))]
     pub(crate) client_provided_name: String,
 }
 
@@ -47,22 +59,54 @@ impl Debug for ClientOptions {
             .finish()
     }
 }
+
 impl Default for ClientOptions {
     fn default() -> Self {
         ClientOptions {
-            host: "localhost".to_owned(),
-            port: 5552,
-            user: "guest".to_owned(),
-            password: "guest".to_owned(),
-            v_host: "/".to_owned(),
-            heartbeat: 60,
-            max_frame_size: 1048576,
-            load_balancer_mode: false,
-            collector: Arc::new(NopMetricsCollector {}),
+            host: default_host(),
+            port: default_port(),
+            user: default_user(),
+            password: default_password(),
+            v_host: default_v_host(),
+            heartbeat: default_heartbeat(),
+            max_frame_size: default_max_frame_size(),
+            load_balancer_mode: default_load_balancer_mode(),
+            collector: default_collector(),
             tls: Default::default(),
-            client_provided_name: String::from("rust-stream"),
+            client_provided_name: default_client_provided_name(),
         }
     }
+}
+
+fn default_host() -> String {
+    "localhost".to_owned()
+}
+fn default_port() -> u16 {
+    5552
+}
+fn default_user() -> String {
+    "guest".to_owned()
+}
+fn default_password() -> String {
+    "guest".to_owned()
+}
+fn default_v_host() -> String {
+    "/".to_owned()
+}
+fn default_heartbeat() -> u32 {
+    60
+}
+fn default_max_frame_size() -> u32 {
+    1048576
+}
+fn default_load_balancer_mode() -> bool {
+    false
+}
+fn default_collector() -> Arc<dyn MetricsCollector> {
+    Arc::new(NopMetricsCollector {})
+}
+fn default_client_provided_name() -> String {
+    "rust-stream".to_owned()
 }
 
 impl ClientOptions {
@@ -195,8 +239,9 @@ impl ClientOptionsBuilder {
 }
 
 /** Helper for tls configuration */
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub enum TlsConfiguration {
+    #[default]
     Disabled,
     Untrusted,
     Trusted {
@@ -204,9 +249,42 @@ pub enum TlsConfiguration {
         client_certificates: Option<ClientTlsConfiguration>,
     },
 }
-impl Default for TlsConfiguration {
-    fn default() -> Self {
-        TlsConfiguration::Disabled
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TlsConfiguration {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::Deserialize;
+
+        #[derive(Deserialize)]
+        struct DeserializableTlsConfiguration {
+            enabled: bool,
+            root_certificates_path: Option<PathBuf>,
+            client_certificates_path: Option<PathBuf>,
+            client_private_key_path: Option<PathBuf>,
+        }
+        let c = DeserializableTlsConfiguration::deserialize(deserializer)?;
+
+        let builder = TlsConfiguration::builder().enable(c.enabled);
+        let builder = if let Some(root_certificates_path) = c.root_certificates_path {
+            builder.add_root_certificates(root_certificates_path)
+        } else {
+            builder
+        };
+        let builder = if let Some(client_certificates_path) = c.client_certificates_path {
+            builder.add_client_certificates_path(client_certificates_path)
+        } else {
+            builder
+        };
+        let builder = if let Some(client_private_key_path) = c.client_private_key_path {
+            builder.add_client_private_key_path(client_private_key_path)
+        } else {
+            builder
+        };
+
+        builder.build().map_err(serde::de::Error::custom)
     }
 }
 
@@ -227,21 +305,12 @@ impl TlsConfiguration {
     }
 }
 
+#[derive(Default)]
 pub struct TlsConfigurationBuilder {
     enabled: bool,
     root_certificates_path: Option<PathBuf>,
     client_certificates_path: Option<PathBuf>,
     client_private_key_path: Option<PathBuf>,
-}
-impl Default for TlsConfigurationBuilder {
-    fn default() -> Self {
-        TlsConfigurationBuilder {
-            enabled: false,
-            root_certificates_path: None,
-            client_certificates_path: None,
-            client_private_key_path: None,
-        }
-    }
 }
 
 impl TlsConfigurationBuilder {
@@ -255,6 +324,30 @@ impl TlsConfigurationBuilder {
         T: Into<PathBuf>,
     {
         self.root_certificates_path = Some(root_certificates_path.into());
+        self
+    }
+
+    #[cfg(feature = "serde")]
+    fn add_client_certificates_path<T>(
+        mut self,
+        client_certificates_path: T,
+    ) -> TlsConfigurationBuilder
+    where
+        T: Into<PathBuf>,
+    {
+        self.client_certificates_path = Some(client_certificates_path.into());
+        self
+    }
+
+    #[cfg(feature = "serde")]
+    fn add_client_private_key_path<T>(
+        mut self,
+        client_private_key_path: T,
+    ) -> TlsConfigurationBuilder
+    where
+        T: Into<PathBuf>,
+    {
+        self.client_private_key_path = Some(client_private_key_path.into());
         self
     }
 
@@ -295,8 +388,7 @@ impl TlsConfigurationBuilder {
                         })
                     }
                     (None, None) => None,
-                    // This state is unreachable because the properties are set together
-                    _ => unreachable!("Unreachable state"),
+                    _ => return Err("Both client certificates and private key paths are required"),
                 };
 
             Ok(TlsConfiguration::Trusted {
@@ -499,5 +591,264 @@ mod tests {
         assert_eq!(options.max_frame_size, 1);
         assert!(matches!(options.tls, TlsConfiguration::Untrusted));
         assert_eq!(options.load_balancer_mode, true);
+    }
+
+    #[cfg(feature = "serde")]
+    mod serde {
+        use super::*;
+
+        #[test]
+        fn test_tls_builder() {
+            let config = TlsConfiguration::builder().enable(true).build();
+            assert!(matches!(config, Ok(TlsConfiguration::Untrusted)));
+
+            let config = TlsConfiguration::builder()
+                .enable(true)
+                .add_client_certificates_path("cert")
+                .build();
+            assert!(matches!(config, Err(_)));
+
+            let config = TlsConfiguration::builder()
+                .enable(true)
+                .add_client_private_key_path("priv")
+                .build();
+            assert!(matches!(config, Err(_)));
+        }
+    }
+}
+
+#[cfg(all(feature = "serde", test))]
+mod serde_test {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn deserialize_client() {
+        #[derive(serde::Deserialize)]
+        struct MyConfig {
+            #[serde(default)]
+            rabbit: ClientOptions,
+        }
+        let j = r#"{}"#;
+
+        let config: MyConfig = serde_json::from_str(j).unwrap();
+        assert_eq!(config.rabbit.host, default_host());
+        assert_eq!(config.rabbit.port, default_port());
+        assert_eq!(config.rabbit.user, default_user());
+        assert_eq!(config.rabbit.password, default_password());
+        assert_eq!(config.rabbit.v_host, default_v_host());
+        assert_eq!(config.rabbit.heartbeat, default_heartbeat());
+        assert_eq!(config.rabbit.max_frame_size, default_max_frame_size());
+        assert_eq!(
+            config.rabbit.load_balancer_mode,
+            default_load_balancer_mode()
+        );
+        assert_eq!(
+            config.rabbit.client_provided_name,
+            default_client_provided_name()
+        );
+        assert!(matches!(config.rabbit.tls, TlsConfiguration::Disabled));
+
+        let j = r#"{ "rabbit": {} }"#;
+        let config: MyConfig = serde_json::from_str(j).unwrap();
+        assert_eq!(config.rabbit.host, default_host());
+        assert_eq!(config.rabbit.port, default_port());
+        assert_eq!(config.rabbit.user, default_user());
+        assert_eq!(config.rabbit.password, default_password());
+        assert_eq!(config.rabbit.v_host, default_v_host());
+        assert_eq!(config.rabbit.heartbeat, default_heartbeat());
+        assert_eq!(config.rabbit.max_frame_size, default_max_frame_size());
+        assert_eq!(
+            config.rabbit.load_balancer_mode,
+            default_load_balancer_mode()
+        );
+        assert_eq!(
+            config.rabbit.client_provided_name,
+            default_client_provided_name()
+        );
+        assert!(matches!(config.rabbit.tls, TlsConfiguration::Disabled));
+
+        let j = r#"{ "rabbit": {"host": "example.org"} }"#;
+        let config: MyConfig = serde_json::from_str(j).unwrap();
+        assert_eq!(config.rabbit.host, "example.org".to_string());
+        assert_eq!(config.rabbit.port, default_port());
+        assert_eq!(config.rabbit.user, default_user());
+        assert_eq!(config.rabbit.password, default_password());
+        assert_eq!(config.rabbit.v_host, default_v_host());
+        assert_eq!(config.rabbit.heartbeat, default_heartbeat());
+        assert_eq!(config.rabbit.max_frame_size, default_max_frame_size());
+        assert_eq!(
+            config.rabbit.load_balancer_mode,
+            default_load_balancer_mode()
+        );
+        assert_eq!(
+            config.rabbit.client_provided_name,
+            default_client_provided_name()
+        );
+        assert!(matches!(config.rabbit.tls, TlsConfiguration::Disabled));
+
+        let j = r#"{ "rabbit": {"host": "example.org", "port": 5354} }"#;
+        let config: MyConfig = serde_json::from_str(j).unwrap();
+        assert_eq!(config.rabbit.host, "example.org".to_string());
+        assert_eq!(config.rabbit.port, 5354);
+        assert_eq!(config.rabbit.user, default_user());
+        assert_eq!(config.rabbit.password, default_password());
+        assert_eq!(config.rabbit.v_host, default_v_host());
+        assert_eq!(config.rabbit.heartbeat, default_heartbeat());
+        assert_eq!(config.rabbit.max_frame_size, default_max_frame_size());
+        assert_eq!(
+            config.rabbit.load_balancer_mode,
+            default_load_balancer_mode()
+        );
+        assert_eq!(
+            config.rabbit.client_provided_name,
+            default_client_provided_name()
+        );
+        assert!(matches!(config.rabbit.tls, TlsConfiguration::Disabled));
+
+        let j = r#"{ "rabbit": { "tls": {} } }"#;
+        let config = serde_json::from_str::<MyConfig>(j);
+        assert!(config.is_err());
+
+        let j = r#"{ "rabbit": { "tls": { "enabled": false } } }"#;
+        let config = serde_json::from_str::<MyConfig>(j).unwrap();
+        assert!(matches!(config.rabbit.tls, TlsConfiguration::Disabled));
+
+        let j = r#"{ "rabbit": { "tls": { "enabled": true } } }"#;
+        let config = serde_json::from_str::<MyConfig>(j).unwrap();
+        assert!(matches!(config.rabbit.tls, TlsConfiguration::Untrusted));
+
+        let j = r#"
+{
+    "rabbit": {
+        "tls": {
+            "enabled": true,
+            "root_certificates_path": "path"
+        }
+    }
+}"#;
+        let config = serde_json::from_str::<MyConfig>(j).unwrap();
+        assert!(matches!(
+            config.rabbit.tls,
+            TlsConfiguration::Trusted { .. }
+        ));
+        let TlsConfiguration::Trusted {
+            root_certificates_path,
+            client_certificates,
+        } = config.rabbit.tls
+        else {
+            panic!("Expected Trusted configuration")
+        };
+        assert_eq!(root_certificates_path.as_path(), Path::new("path"));
+        assert!(client_certificates.is_none());
+
+        let j = r#"
+{
+    "rabbit": {
+        "tls": {
+            "enabled": true,
+            "root_certificates_path": "path",
+            "client_certificates_path": "cert",
+            "client_private_key_path": "priv"
+        }
+    }
+}"#;
+        let config = serde_json::from_str::<MyConfig>(j).unwrap();
+        assert!(matches!(
+            config.rabbit.tls,
+            TlsConfiguration::Trusted { .. }
+        ));
+        let TlsConfiguration::Trusted {
+            root_certificates_path,
+            client_certificates,
+        } = config.rabbit.tls
+        else {
+            panic!("Expected Trusted configuration")
+        };
+        assert_eq!(root_certificates_path.as_path(), Path::new("path"));
+        let client_certificates = client_certificates.expect("Expected client certificates");
+        assert_eq!(
+            client_certificates.client_certificates_path.as_path(),
+            Path::new("cert")
+        );
+        assert_eq!(
+            client_certificates.client_private_key_path.as_path(),
+            Path::new("priv")
+        );
+    }
+
+    #[test]
+    fn test_tls_config() {
+        let j = r#"
+{}"#;
+        let config = serde_json::from_str::<TlsConfiguration>(j);
+        assert!(config.is_err());
+
+        let j = r#"
+{
+    "enabled": false
+}"#;
+        let config: TlsConfiguration = serde_json::from_str(j).unwrap();
+        assert!(matches!(config, TlsConfiguration::Disabled));
+
+        let j = r#"
+{
+    "enabled": true
+}"#;
+        let config: TlsConfiguration = serde_json::from_str(j).unwrap();
+        assert!(matches!(config, TlsConfiguration::Untrusted));
+
+        let j = r#"
+{
+    "enabled": true,
+    "root_certificates_path": "test"
+}"#;
+        let config: TlsConfiguration = serde_json::from_str(j).unwrap();
+        assert!(matches!(config, TlsConfiguration::Trusted { .. }));
+        let TlsConfiguration::Trusted {
+            root_certificates_path,
+            client_certificates,
+        } = config
+        else {
+            panic!("Expected Trusted configuration")
+        };
+        assert_eq!(root_certificates_path.as_path(), Path::new("test"));
+        assert!(client_certificates.is_none());
+
+        let j = r#"
+{
+    "enabled": true,
+    "root_certificates_path": "test",
+    "client_certificates_path": "cert"
+}"#;
+        let config = serde_json::from_str::<TlsConfiguration>(j);
+        assert!(config.is_err());
+
+        let j = r#"
+{
+    "enabled": true,
+    "root_certificates_path": "test",
+    "client_certificates_path": "cert",
+    "client_private_key_path": "priv"
+}"#;
+        let config: TlsConfiguration = serde_json::from_str(j).unwrap();
+        assert!(matches!(config, TlsConfiguration::Trusted { .. }));
+        let TlsConfiguration::Trusted {
+            root_certificates_path,
+            client_certificates,
+        } = config
+        else {
+            panic!("Expected Trusted configuration")
+        };
+        assert_eq!(root_certificates_path.as_path(), Path::new("test"));
+        let client_certificates = client_certificates.expect("Expected client certificates");
+        assert_eq!(
+            client_certificates.client_certificates_path.as_path(),
+            Path::new("cert")
+        );
+        assert_eq!(
+            client_certificates.client_private_key_path.as_path(),
+            Path::new("priv")
+        );
     }
 }

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -1,6 +1,22 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{convert::TryFrom, fmt::Debug, path::PathBuf, sync::Arc};
 
-use super::metrics::{MetricsCollector, NopMetricsCollector};
+use tokio::net::TcpStream;
+use tokio_rustls::rustls::pki_types::ServerName;
+use tokio_rustls::{
+    rustls::{
+        self,
+        pki_types::{CertificateDer, PrivateKeyDer},
+        ClientConfig,
+    },
+    TlsConnector,
+};
+
+use crate::error::ClientError;
+
+use super::{
+    metrics::{MetricsCollector, NopMetricsCollector},
+    GenericTcpStream,
+};
 
 #[derive(Clone)]
 pub struct ClientOptions {
@@ -43,13 +59,7 @@ impl Default for ClientOptions {
             max_frame_size: 1048576,
             load_balancer_mode: false,
             collector: Arc::new(NopMetricsCollector {}),
-            tls: TlsConfiguration {
-                enabled: false,
-                trust_certificates: false,
-                root_certificates_path: String::from(""),
-                client_certificates_path: String::from(""),
-                client_keys_path: String::from(""),
-            },
+            tls: Default::default(),
             client_provided_name: String::from("rust-stream"),
         }
     }
@@ -60,20 +70,69 @@ impl ClientOptions {
         ClientOptionsBuilder(ClientOptions::default())
     }
 
-    pub fn get_tls(&self) -> TlsConfiguration {
-        self.tls.clone()
-    }
-
-    pub fn enable_tls(&mut self) {
-        self.tls.enable(true);
-    }
-
     pub fn set_port(&mut self, port: u16) {
         self.port = port;
     }
 
     pub fn set_client_provided_name(&mut self, name: &str) {
         self.client_provided_name = name.to_owned();
+    }
+
+    pub(crate) async fn build_generic_tcp_stream(&self) -> Result<GenericTcpStream, ClientError> {
+        async fn create_tls_connection(
+            host: String,
+            port: u16,
+            config: ClientConfig,
+        ) -> Result<GenericTcpStream, ClientError> {
+            let stream = TcpStream::connect((host.clone(), port)).await?;
+            let domain = ServerName::try_from(host.clone()).unwrap();
+            let connector = TlsConnector::from(Arc::new(config));
+            let conn = connector.connect(domain, stream).await?;
+            Ok(GenericTcpStream::SecureTcp(conn))
+        }
+        match &self.tls {
+            TlsConfiguration::Trusted {
+                root_certificates_path,
+                client_certificates,
+            } => {
+                let roots = build_root_store(root_certificates_path).await?;
+
+                let builder = ClientConfig::builder().with_root_certificates(roots);
+                let config = match client_certificates {
+                    Some(client_certificates) => {
+                        let client_certs = match build_client_certificates(
+                            &client_certificates.client_certificates_path,
+                        ) {
+                            Ok(certs) => certs,
+                            Err(e) => return Err(ClientError::Io(e)),
+                        };
+                        let client_keys = match build_client_private_keys(
+                            &client_certificates.client_private_key_path,
+                        ) {
+                            Ok(keys) => keys,
+                            Err(e) => return Err(ClientError::Io(e)),
+                        };
+                        match builder.with_client_auth_cert(
+                            client_certs,
+                            client_keys.into_iter().next().unwrap(),
+                        ) {
+                            Ok(config) => config,
+                            Err(e) => return Err(ClientError::GenericError(Box::new(e))),
+                        }
+                    }
+                    None => builder.with_no_client_auth(),
+                };
+                create_tls_connection(self.host.clone(), self.port, config).await
+            }
+            TlsConfiguration::Untrusted => {
+                let config: ClientConfig = build_tls_client_configuration_untrusted().await?;
+                create_tls_connection(self.host.clone(), self.port, config).await
+            }
+            TlsConfiguration::Disabled => {
+                let stream = TcpStream::connect((self.host.as_str(), self.port)).await?;
+                Ok(GenericTcpStream::Tcp(stream))
+            }
+        }
     }
 }
 
@@ -135,10 +194,287 @@ impl ClientOptionsBuilder {
     }
 }
 
+/** Helper for tls configuration */
+#[derive(Clone)]
+pub enum TlsConfiguration {
+    Disabled,
+    Untrusted,
+    Trusted {
+        root_certificates_path: PathBuf,
+        client_certificates: Option<ClientTlsConfiguration>,
+    },
+}
+impl Default for TlsConfiguration {
+    fn default() -> Self {
+        TlsConfiguration::Disabled
+    }
+}
+
+#[derive(Clone)]
+pub struct ClientTlsConfiguration {
+    pub(crate) client_certificates_path: PathBuf,
+    pub(crate) client_private_key_path: PathBuf,
+}
+
+impl TlsConfiguration {
+    pub fn builder() -> TlsConfigurationBuilder {
+        TlsConfigurationBuilder {
+            enabled: false,
+            root_certificates_path: None,
+            client_certificates_path: None,
+            client_private_key_path: None,
+        }
+    }
+}
+
+pub struct TlsConfigurationBuilder {
+    enabled: bool,
+    root_certificates_path: Option<PathBuf>,
+    client_certificates_path: Option<PathBuf>,
+    client_private_key_path: Option<PathBuf>,
+}
+impl Default for TlsConfigurationBuilder {
+    fn default() -> Self {
+        TlsConfigurationBuilder {
+            enabled: false,
+            root_certificates_path: None,
+            client_certificates_path: None,
+            client_private_key_path: None,
+        }
+    }
+}
+
+impl TlsConfigurationBuilder {
+    pub fn enable(mut self, enabled: bool) -> TlsConfigurationBuilder {
+        self.enabled = enabled;
+        self
+    }
+
+    pub fn add_root_certificates<T>(mut self, root_certificates_path: T) -> TlsConfigurationBuilder
+    where
+        T: Into<PathBuf>,
+    {
+        self.root_certificates_path = Some(root_certificates_path.into());
+        self
+    }
+
+    pub fn add_client_certificates_keys<T1, T2>(
+        mut self,
+        client_certificates_path: T1,
+        client_private_key_path: T2,
+    ) -> TlsConfigurationBuilder
+    where
+        T1: Into<PathBuf>,
+        T2: Into<PathBuf>,
+    {
+        self.client_certificates_path = Some(client_certificates_path.into());
+        self.client_private_key_path = Some(client_private_key_path.into());
+        self
+    }
+
+    pub fn build(self) -> Result<TlsConfiguration, &'static str> {
+        if self.enabled {
+            let root_certificates_path = match self.root_certificates_path {
+                Some(root_certificates_path) => root_certificates_path,
+                None => {
+                    if self.client_certificates_path.is_some()
+                        || self.client_private_key_path.is_some()
+                    {
+                        return Err("Root certificates path is required when client certificates are provided");
+                    }
+                    return Ok(TlsConfiguration::Untrusted);
+                }
+            };
+
+            let client_certificates =
+                match (self.client_certificates_path, self.client_private_key_path) {
+                    (Some(client_certificates_path), Some(client_private_key_path)) => {
+                        Some(ClientTlsConfiguration {
+                            client_certificates_path,
+                            client_private_key_path,
+                        })
+                    }
+                    (None, None) => None,
+                    // This state is unreachable because the properties are set together
+                    _ => unreachable!("Unreachable state"),
+                };
+
+            Ok(TlsConfiguration::Trusted {
+                root_certificates_path,
+                client_certificates,
+            })
+        } else {
+            Ok(TlsConfiguration::Disabled)
+        }
+    }
+}
+
+fn build_client_certificates(
+    client_cert: &PathBuf,
+) -> std::io::Result<Vec<CertificateDer<'static>>> {
+    let file = std::fs::File::open(client_cert)?;
+    let mut pem = std::io::BufReader::new(file);
+    rustls_pemfile::certs(&mut pem)
+        .map(|c| c.map(CertificateDer::into_owned))
+        .collect()
+}
+
+async fn build_tls_client_configuration_untrusted() -> Result<ClientConfig, ClientError> {
+    mod danger {
+        use rustls::client::danger::HandshakeSignatureValid;
+        use rustls::client::danger::ServerCertVerified;
+        use tokio_rustls::rustls::{
+            self, client::danger::ServerCertVerifier, pki_types::ServerName,
+        };
+
+        #[derive(Debug)]
+        pub struct NoCertificateVerification {}
+
+        impl ServerCertVerifier for NoCertificateVerification {
+            fn verify_tls12_signature(
+                &self,
+                _: &[u8],
+                _: &rustls::pki_types::CertificateDer<'_>,
+                _: &rustls::DigitallySignedStruct,
+            ) -> Result<HandshakeSignatureValid, rustls::Error> {
+                Ok(HandshakeSignatureValid::assertion())
+            }
+
+            fn verify_tls13_signature(
+                &self,
+                _: &[u8],
+                _: &rustls::pki_types::CertificateDer<'_>,
+                _: &rustls::DigitallySignedStruct,
+            ) -> Result<HandshakeSignatureValid, rustls::Error> {
+                Ok(HandshakeSignatureValid::assertion())
+            }
+
+            fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+                use rustls::SignatureScheme;
+                // I know know if this is correct
+                vec![
+                    SignatureScheme::RSA_PKCS1_SHA1,
+                    SignatureScheme::ECDSA_SHA1_Legacy,
+                    SignatureScheme::RSA_PKCS1_SHA256,
+                    SignatureScheme::ECDSA_NISTP256_SHA256,
+                    SignatureScheme::RSA_PKCS1_SHA384,
+                    SignatureScheme::ECDSA_NISTP384_SHA384,
+                    SignatureScheme::RSA_PKCS1_SHA512,
+                    SignatureScheme::ECDSA_NISTP521_SHA512,
+                    SignatureScheme::RSA_PSS_SHA256,
+                    SignatureScheme::RSA_PSS_SHA384,
+                    SignatureScheme::RSA_PSS_SHA512,
+                    SignatureScheme::ED25519,
+                    SignatureScheme::ED448,
+                ]
+            }
+
+            fn verify_server_cert(
+                &self,
+                _: &rustls::pki_types::CertificateDer<'_>,
+                _: &[rustls::pki_types::CertificateDer<'_>],
+                _: &ServerName<'_>,
+                _: &[u8],
+                _: rustls::pki_types::UnixTime,
+            ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+                Ok(ServerCertVerified::assertion())
+            }
+        }
+    }
+
+    let config = ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(danger::NoCertificateVerification {}))
+        .with_no_client_auth();
+
+    Ok(config)
+}
+
+async fn build_root_store(root_ca_cert: &PathBuf) -> std::io::Result<rustls::RootCertStore> {
+    let mut roots = rustls::RootCertStore::empty();
+    let cert_bytes = std::fs::read(root_ca_cert)?;
+
+    let root_cert_store: Result<Vec<_>, _> =
+        rustls_pemfile::certs(&mut cert_bytes.as_ref()).collect();
+    let root_cert_store = root_cert_store?;
+
+    root_cert_store
+        .into_iter()
+        .for_each(|cert| roots.add(cert).unwrap());
+    Ok(roots)
+}
+
+fn build_client_private_keys(
+    client_private_key: &PathBuf,
+) -> std::io::Result<Vec<PrivateKeyDer<'static>>> {
+    let file = std::fs::File::open(client_private_key)?;
+    let mut pem = std::io::BufReader::new(file);
+    let keys: Result<Vec<_>, _> = rustls_pemfile::pkcs8_private_keys(&mut pem).collect();
+    let keys = keys?;
+    let keys = keys.into_iter().map(PrivateKeyDer::from).collect();
+    Ok(keys)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ClientOptions, NopMetricsCollector, TlsConfiguration};
-    use std::sync::Arc;
+    use super::*;
+    use std::{path::Path, sync::Arc};
+
+    #[test]
+    fn test_tls_builder() {
+        let tls = TlsConfiguration::builder().build().unwrap();
+        assert!(matches!(tls, TlsConfiguration::Disabled));
+        let tls = TlsConfiguration::builder().enable(true).build().unwrap();
+        assert!(matches!(tls, TlsConfiguration::Untrusted));
+
+        let tls = TlsConfiguration::builder()
+            .enable(true)
+            .add_root_certificates("test")
+            .build()
+            .unwrap();
+        let TlsConfiguration::Trusted {
+            root_certificates_path,
+            client_certificates,
+        } = tls
+        else {
+            panic!("Expected Trusted configuration")
+        };
+        assert_eq!(root_certificates_path.as_path(), Path::new("test"));
+        assert!(client_certificates.is_none());
+
+        let tls = TlsConfiguration::builder()
+            .enable(true)
+            .add_root_certificates("test")
+            .add_client_certificates_keys("cert", "priv")
+            .build()
+            .unwrap();
+        let TlsConfiguration::Trusted {
+            root_certificates_path,
+            client_certificates,
+        } = tls
+        else {
+            panic!("Expected Trusted configuration")
+        };
+        assert_eq!(root_certificates_path.as_path(), Path::new("test"));
+        let Some(client_certificates) = client_certificates else {
+            panic!("Expected client certificates")
+        };
+        assert_eq!(
+            client_certificates.client_certificates_path,
+            Path::new("cert")
+        );
+        assert_eq!(
+            client_certificates.client_private_key_path,
+            Path::new("priv")
+        );
+
+        let tls = TlsConfiguration::builder()
+            .enable(true)
+            // .add_root_certificates("test")
+            .add_client_certificates_keys("cert", "priv")
+            .build();
+        assert!(tls.is_err());
+    }
 
     #[test]
     fn test_client_options_builder() {
@@ -150,13 +486,7 @@ mod tests {
             .v_host("/test_vhost")
             .heartbeat(10000)
             .max_frame_size(1)
-            .tls(TlsConfiguration {
-                enabled: true,
-                trust_certificates: false,
-                root_certificates_path: String::from(""),
-                client_certificates_path: String::from(""),
-                client_keys_path: String::from(""),
-            })
+            .tls(TlsConfiguration::builder().enable(true).build().unwrap())
             .collector(Arc::new(NopMetricsCollector {}))
             .load_balancer_mode(true)
             .build();
@@ -167,111 +497,7 @@ mod tests {
         assert_eq!(options.v_host, "/test_vhost");
         assert_eq!(options.heartbeat, 10000);
         assert_eq!(options.max_frame_size, 1);
-        assert_eq!(options.tls.enabled, true);
+        assert!(matches!(options.tls, TlsConfiguration::Untrusted));
         assert_eq!(options.load_balancer_mode, true);
-    }
-}
-
-/** Helper for tls configuration */
-#[derive(Clone)]
-pub struct TlsConfiguration {
-    pub(crate) enabled: bool,
-    pub(crate) trust_certificates: bool,
-    pub(crate) root_certificates_path: String,
-    pub(crate) client_certificates_path: String,
-    pub(crate) client_keys_path: String,
-}
-
-impl Default for TlsConfiguration {
-    fn default() -> TlsConfiguration {
-        TlsConfiguration {
-            enabled: true,
-            trust_certificates: false,
-            root_certificates_path: String::from(""),
-            client_certificates_path: String::from(""),
-            client_keys_path: String::from(""),
-        }
-    }
-}
-
-impl TlsConfiguration {
-    pub fn enable(&mut self, enabled: bool) {
-        self.enabled = enabled
-    }
-
-    pub fn enabled(&self) -> bool {
-        self.enabled
-    }
-
-    pub fn trust_certificates(&mut self, trust_certificates: bool) {
-        self.trust_certificates = trust_certificates
-    }
-
-    pub fn trust_certificates_enabled(&self) -> bool {
-        self.trust_certificates
-    }
-
-    pub fn get_root_certificates_path(&self) -> String {
-        self.root_certificates_path.clone()
-    }
-    //
-    pub fn add_root_certificates_path(&mut self, certificate_path: String) {
-        self.root_certificates_path = certificate_path
-    }
-
-    pub fn get_client_certificates_path(&self) -> String {
-        self.client_certificates_path.clone()
-    }
-
-    pub fn get_client_keys_path(&self) -> String {
-        self.client_keys_path.clone()
-    }
-    //
-    pub fn add_client_certificates_keys(
-        &mut self,
-        certificate_path: String,
-        client_private_key_path: String,
-    ) {
-        self.client_certificates_path = certificate_path;
-        self.client_keys_path = client_private_key_path;
-    }
-}
-
-pub struct TlsConfigurationBuilder(TlsConfiguration);
-
-impl TlsConfigurationBuilder {
-    pub fn enable(mut self, enable: bool) -> TlsConfigurationBuilder {
-        self.0.enabled = enable;
-        self
-    }
-
-    pub fn trust_certificates(mut self, trust_certificates: bool) -> TlsConfigurationBuilder {
-        self.0.trust_certificates = trust_certificates;
-        self
-    }
-
-    pub fn add_root_certificates(mut self, certificate_path: String) -> TlsConfigurationBuilder {
-        self.0.root_certificates_path = certificate_path;
-        self
-    }
-
-    pub fn add_client_certificates_keys(
-        mut self,
-        certificate_path: String,
-        client_private_key_path: String,
-    ) -> TlsConfigurationBuilder {
-        self.0.client_certificates_path = certificate_path;
-        self.0.client_keys_path = client_private_key_path;
-        self
-    }
-
-    pub fn build(self) -> TlsConfiguration {
-        self.0
-    }
-}
-
-impl TlsConfiguration {
-    pub fn builder() -> TlsConfigurationBuilder {
-        TlsConfigurationBuilder(TlsConfiguration::default())
     }
 }

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -560,7 +560,6 @@ mod tests {
 
         let tls = TlsConfiguration::builder()
             .enable(true)
-            // .add_root_certificates("test")
             .add_client_certificates_keys("cert", "priv")
             .build();
         assert!(tls.is_err());

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -2,8 +2,8 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::producer::NoDedup;
 use crate::types::OffsetSpecification;
+use crate::{client::TlsConfiguration, producer::NoDedup};
 use rand::prelude::SliceRandom;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -310,108 +310,4 @@ impl EnvironmentBuilder {
 #[derive(Clone, Default)]
 pub struct EnvironmentOptions {
     pub(crate) client_options: ClientOptions,
-}
-
-/** Helper for tls configuration */
-#[derive(Clone)]
-pub struct TlsConfiguration {
-    pub(crate) enabled: bool,
-    pub(crate) trust_certificates: bool,
-    pub(crate) root_certificates_path: String,
-    pub(crate) client_certificates_path: String,
-    pub(crate) client_keys_path: String,
-}
-
-impl Default for TlsConfiguration {
-    fn default() -> TlsConfiguration {
-        TlsConfiguration {
-            enabled: true,
-            trust_certificates: false,
-            root_certificates_path: String::from(""),
-            client_certificates_path: String::from(""),
-            client_keys_path: String::from(""),
-        }
-    }
-}
-
-impl TlsConfiguration {
-    pub fn enable(&mut self, enabled: bool) {
-        self.enabled = enabled
-    }
-
-    pub fn enabled(&self) -> bool {
-        self.enabled
-    }
-
-    pub fn trust_certificates(&mut self, trust_certificates: bool) {
-        self.trust_certificates = trust_certificates
-    }
-
-    pub fn trust_certificates_enabled(&self) -> bool {
-        self.trust_certificates
-    }
-
-    pub fn get_root_certificates_path(&self) -> String {
-        self.root_certificates_path.clone()
-    }
-    //
-    pub fn add_root_certificates_path(&mut self, certificate_path: String) {
-        self.root_certificates_path = certificate_path
-    }
-
-    pub fn get_client_certificates_path(&self) -> String {
-        self.client_certificates_path.clone()
-    }
-
-    pub fn get_client_keys_path(&self) -> String {
-        self.client_keys_path.clone()
-    }
-    //
-    pub fn add_client_certificates_keys(
-        &mut self,
-        certificate_path: String,
-        client_private_key_path: String,
-    ) {
-        self.client_certificates_path = certificate_path;
-        self.client_keys_path = client_private_key_path;
-    }
-}
-
-pub struct TlsConfigurationBuilder(TlsConfiguration);
-
-impl TlsConfigurationBuilder {
-    pub fn enable(mut self, enable: bool) -> TlsConfigurationBuilder {
-        self.0.enabled = enable;
-        self
-    }
-
-    pub fn trust_certificates(mut self, trust_certificates: bool) -> TlsConfigurationBuilder {
-        self.0.trust_certificates = trust_certificates;
-        self
-    }
-
-    pub fn add_root_certificates(mut self, certificate_path: String) -> TlsConfigurationBuilder {
-        self.0.root_certificates_path = certificate_path;
-        self
-    }
-
-    pub fn add_client_certificates_keys(
-        mut self,
-        certificate_path: String,
-        client_private_key_path: String,
-    ) -> TlsConfigurationBuilder {
-        self.0.client_certificates_path = certificate_path;
-        self.0.client_keys_path = client_private_key_path;
-        self
-    }
-
-    pub fn build(self) -> TlsConfiguration {
-        self.0
-    }
-}
-
-impl TlsConfiguration {
-    pub fn builder() -> TlsConfigurationBuilder {
-        TlsConfigurationBuilder(TlsConfiguration::default())
-    }
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -32,6 +32,34 @@ impl Environment {
         EnvironmentBuilder(EnvironmentOptions::default())
     }
 
+    /// Create environment instance from client options.
+    /// This allow to create an `Environment` instance from configuration.
+    ///
+    /// ```rust,no_run
+    /// # async fn doc_fn() -> Result<(), Box<dyn std::error::Error>> {
+    /// use rabbitmq_stream_client::Environment;
+    /// use rabbitmq_stream_client::ClientOptions;
+    ///
+    /// struct MyConfig {
+    ///     rabbitmq: ClientOptions
+    /// }
+    ///
+    /// let j = r#"
+    /// {
+    ///     "rabbitmq": {
+    ///         "host": "localhost",
+    ///         "tls": {
+    ///             "enabled": false
+    ///         }
+    ///     }
+    /// }
+    ///         "#;
+    ///  let my_config: MyConfig = serde_json::from_str(j).unwrap();
+    ///  let env = Environment::from_client_option(my_config.rabbitmq)
+    ///     .await
+    ///     .unwrap();
+    /// # Ok(())
+    /// # }
     #[cfg(feature = "serde")]
     pub async fn from_client_option(
         client_options: impl Into<ClientOptions>,

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -32,6 +32,16 @@ impl Environment {
         EnvironmentBuilder(EnvironmentOptions::default())
     }
 
+    #[cfg(feature = "serde")]
+    pub async fn from_client_option(
+        client_options: impl Into<ClientOptions>,
+    ) -> RabbitMQStreamResult<Self> {
+        let env_option = EnvironmentOptions {
+            client_options: client_options.into(),
+        };
+        Self::boostrap(env_option).await
+    }
+
     async fn boostrap(options: EnvironmentOptions) -> RabbitMQStreamResult<Self> {
         // check connection
         let client = Client::connect(options.client_options.clone()).await?;

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -40,6 +40,7 @@ impl Environment {
     /// use rabbitmq_stream_client::Environment;
     /// use rabbitmq_stream_client::ClientOptions;
     ///
+    /// #[derive(serde::Deserialize)]
     /// struct MyConfig {
     ///     rabbitmq: ClientOptions
     /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,12 +85,14 @@ mod superstream_producer;
 
 pub type RabbitMQStreamResult<T> = Result<T, error::ClientError>;
 
-pub use crate::client::{Client, ClientOptions, MetricsCollector};
+pub use crate::client::{
+    Client, ClientOptions, MetricsCollector, TlsConfiguration, TlsConfigurationBuilder,
+};
 
 pub use crate::consumer::{
     Consumer, ConsumerBuilder, ConsumerHandle, FilterConfiguration, MessageContext,
 };
-pub use crate::environment::{Environment, EnvironmentBuilder, TlsConfiguration};
+pub use crate::environment::{Environment, EnvironmentBuilder};
 pub use crate::producer::{Dedup, NoDedup, Producer, ProducerBuilder};
 pub mod types {
 

--- a/tests/integration/environment_test.rs
+++ b/tests/integration/environment_test.rs
@@ -157,7 +157,7 @@ async fn environment_tls_connection_trust_certificates() {
     // the test validates that the client can connect to a server
     // that uses tls and the client trusts the server certificate
     let tls_configuration: TlsConfiguration =
-        TlsConfiguration::builder().trust_certificates(true).build();
+        TlsConfiguration::builder().enable(true).build().unwrap();
 
     let env = Environment::builder()
         .host("localhost")
@@ -181,9 +181,9 @@ async fn environment_fail_tls_connection_wrong_certificates() {
         .to_string();
 
     let tls_configuration: TlsConfiguration = TlsConfiguration::builder()
-        .trust_certificates(false)
         .add_root_certificates(path)
-        .build();
+        .build()
+        .unwrap();
 
     let env = Environment::builder()
         .host("localhost")
@@ -209,7 +209,8 @@ async fn environment_tls_connection_with_root_ca() {
 
     let tls_configuration: TlsConfiguration = TlsConfiguration::builder()
         .add_root_certificates(path)
-        .build();
+        .build()
+        .unwrap();
 
     let env = Environment::builder()
         .host("localhost")
@@ -250,7 +251,8 @@ async fn environment_tls_connection_with_root_ca_and_client_certificates() {
     let tls_configuration: TlsConfiguration = TlsConfiguration::builder()
         .add_root_certificates(path_ca)
         .add_client_certificates_keys(path_client_cert, path_client_key)
-        .build();
+        .build()
+        .unwrap();
 
     let env = Environment::builder()
         .host("localhost")

--- a/tests/integration/environment_test.rs
+++ b/tests/integration/environment_test.rs
@@ -13,6 +13,31 @@ async fn environment_create_test() {
     let _ = TestEnvironment::create().await;
 }
 
+#[cfg(all(feature = "serde", test))]
+mod tests {
+    use rabbitmq_stream_client::ClientOptions;
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_environment_build_from_client_option() {
+        let j = r#"
+{
+    "host": "localhost",
+    "tls": {
+        "enabled": false
+    }
+}
+        "#;
+        let stream: String = Faker.fake();
+        let client_options: ClientOptions = serde_json::from_str(j).unwrap();
+        let env = Environment::from_client_option(client_options)
+            .await
+            .unwrap();
+        env.stream_creator().create(&stream).await.unwrap();
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn environment_create_and_delete_super_stream_test() {
     let super_stream = "super_stream_test";


### PR DESCRIPTION
This PR allow the deserialization for `ClientOption` and build `Environment from ClientOption`. See #268 

Changes:
- move `TlsConfiguration` under `client::options`
- `TlsConfiguration` is now an enum
- move the connection logic into `client::options`
- `TlsConfigurationBuilder::.build` may fail (**breaking**) instead of failing on `connect` with an `unwrap`.
- add `serde` feature
- `ClientOptions`, `TlsConfiguration`, and `ByteCapacity` are deserializable
- add test on deserialization
- move defaults to functions so `Default` and `serde` use the same defaults
- add `Environment::from_client_option` under `serde` feature
- add example