### PR TITLE
FnOnce as Producer::send callback

### DIFF
--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -19,6 +19,5 @@ num_enum = "0.7.0"
 derive_more = "0.99"
 
 [dev-dependencies]
-fake = { version = "3.0", features=['derive', 'chrono','uuid']}
-rand = "0.8"
 pretty_assertions = "1.2.0"
+fake = { version = "4.0", features = [ "derive", "chrono", "uuid" ] }

--- a/protocol/src/commands/close.rs
+++ b/protocol/src/commands/close.rs
@@ -17,9 +17,6 @@ use crate::{
 
 use super::Command;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct CloseRequest {

--- a/protocol/src/commands/consumer_update.rs
+++ b/protocol/src/commands/consumer_update.rs
@@ -1,8 +1,5 @@
 use std::io::Write;
 
-#[cfg(test)]
-use fake::Fake;
-
 use crate::{
     codec::{Decoder, Encoder},
     error::{DecodeError, EncodeError},

--- a/protocol/src/commands/consumer_update_request.rs
+++ b/protocol/src/commands/consumer_update_request.rs
@@ -1,8 +1,5 @@
 use std::io::Write;
 
-#[cfg(test)]
-use fake::Fake;
-
 use crate::{
     codec::{Decoder, Encoder},
     error::{DecodeError, EncodeError},

--- a/protocol/src/commands/create_stream.rs
+++ b/protocol/src/commands/create_stream.rs
@@ -9,9 +9,6 @@ use crate::{
 
 use super::Command;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct CreateStreamCommand {

--- a/protocol/src/commands/create_super_stream.rs
+++ b/protocol/src/commands/create_super_stream.rs
@@ -1,9 +1,6 @@
 use std::collections::HashMap;
 use std::io::Write;
 
-#[cfg(test)]
-use fake::Fake;
-
 use crate::{
     codec::{Decoder, Encoder},
     error::{DecodeError, EncodeError},

--- a/protocol/src/commands/credit.rs
+++ b/protocol/src/commands/credit.rs
@@ -1,8 +1,5 @@
 use std::io::Write;
 
-#[cfg(test)]
-use fake::Fake;
-
 use crate::{
     codec::{Decoder, Encoder},
     error::{DecodeError, EncodeError},

--- a/protocol/src/commands/declare_publisher.rs
+++ b/protocol/src/commands/declare_publisher.rs
@@ -8,9 +8,6 @@ use crate::{
 
 use super::Command;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct DeclarePublisherCommand {

--- a/protocol/src/commands/delete.rs
+++ b/protocol/src/commands/delete.rs
@@ -8,9 +8,6 @@ use crate::{
 
 use super::Command;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct Delete {

--- a/protocol/src/commands/delete_publisher.rs
+++ b/protocol/src/commands/delete_publisher.rs
@@ -8,9 +8,6 @@ use crate::{
 
 use super::Command;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct DeletePublisherCommand {

--- a/protocol/src/commands/delete_super_stream.rs
+++ b/protocol/src/commands/delete_super_stream.rs
@@ -1,8 +1,5 @@
 use std::io::Write;
 
-#[cfg(test)]
-use fake::Fake;
-
 use crate::{
     codec::{Decoder, Encoder},
     error::{DecodeError, EncodeError},
@@ -62,7 +59,6 @@ impl Command for DeleteSuperStreamCommand {
 
 #[cfg(test)]
 mod tests {
-    use crate::commands::create_super_stream::CreateSuperStreamCommand;
     use crate::commands::tests::command_encode_decode_test;
 
     use super::DeleteSuperStreamCommand;

--- a/protocol/src/commands/deliver.rs
+++ b/protocol/src/commands/deliver.rs
@@ -9,8 +9,6 @@ use crate::{
     protocol::commands::COMMAND_DELIVER,
 };
 use byteorder::{BigEndian, WriteBytesExt};
-#[cfg(test)]
-use fake::Fake;
 
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -163,7 +161,7 @@ mod tests {
 
     use super::{DeliverCommand, Message};
     impl Dummy<Faker> for Message {
-        fn dummy_with_rng<R: rand::Rng + ?Sized>(_config: &Faker, _rng: &mut R) -> Self {
+        fn dummy_with_rng<R: fake::rand::Rng + ?Sized>(_config: &Faker, _rng: &mut R) -> Self {
             Message::new(InternalMessage::default())
         }
     }

--- a/protocol/src/commands/exchange_command_versions.rs
+++ b/protocol/src/commands/exchange_command_versions.rs
@@ -10,9 +10,6 @@ use crate::{
 use super::Command;
 use byteorder::{BigEndian, WriteBytesExt};
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct ExchangeCommandVersion(u16, u16, u16);

--- a/protocol/src/commands/generic.rs
+++ b/protocol/src/commands/generic.rs
@@ -6,9 +6,6 @@ use crate::{
     FromResponse, ResponseCode, ResponseKind,
 };
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct GenericResponse {

--- a/protocol/src/commands/metadata.rs
+++ b/protocol/src/commands/metadata.rs
@@ -10,8 +10,6 @@ use crate::{
 use super::Command;
 
 use byteorder::{BigEndian, WriteBytesExt};
-#[cfg(test)]
-use fake::Fake;
 
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]

--- a/protocol/src/commands/metadata_update.rs
+++ b/protocol/src/commands/metadata_update.rs
@@ -5,8 +5,6 @@ use crate::{
 use super::Command;
 
 use crate::codec::Encoder;
-#[cfg(test)]
-use fake::Fake;
 
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]

--- a/protocol/src/commands/open.rs
+++ b/protocol/src/commands/open.rs
@@ -10,9 +10,6 @@ use crate::{
 
 use super::Command;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct OpenCommand {

--- a/protocol/src/commands/peer_properties.rs
+++ b/protocol/src/commands/peer_properties.rs
@@ -10,9 +10,6 @@ use crate::{
 
 use super::Command;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct PeerPropertiesCommand {

--- a/protocol/src/commands/publish.rs
+++ b/protocol/src/commands/publish.rs
@@ -11,9 +11,6 @@ use super::Command;
 
 use crate::types::PublishedMessage;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct PublishCommand {

--- a/protocol/src/commands/publish_confirm.rs
+++ b/protocol/src/commands/publish_confirm.rs
@@ -8,9 +8,6 @@ use crate::{
 
 use super::Command;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct PublishConfirm {

--- a/protocol/src/commands/publish_error.rs
+++ b/protocol/src/commands/publish_error.rs
@@ -10,9 +10,6 @@ use std::io::Write;
 
 use super::Command;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct PublishErrorResponse {

--- a/protocol/src/commands/query_offset.rs
+++ b/protocol/src/commands/query_offset.rs
@@ -8,9 +8,6 @@ use std::io::Write;
 
 use super::Command;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct QueryOffsetRequest {

--- a/protocol/src/commands/query_publisher_sequence.rs
+++ b/protocol/src/commands/query_publisher_sequence.rs
@@ -8,9 +8,6 @@ use std::io::Write;
 
 use super::Command;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct QueryPublisherRequest {

--- a/protocol/src/commands/sasl_authenticate.rs
+++ b/protocol/src/commands/sasl_authenticate.rs
@@ -8,9 +8,6 @@ use crate::{
 
 use super::Command;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct SaslAuthenticateCommand {

--- a/protocol/src/commands/sasl_handshake.rs
+++ b/protocol/src/commands/sasl_handshake.rs
@@ -10,9 +10,6 @@ use crate::{
 
 use super::Command;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct SaslHandshakeCommand {

--- a/protocol/src/commands/store_offset.rs
+++ b/protocol/src/commands/store_offset.rs
@@ -7,9 +7,6 @@ use std::io::Write;
 
 use super::Command;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct StoreOffset {

--- a/protocol/src/commands/subscribe.rs
+++ b/protocol/src/commands/subscribe.rs
@@ -1,9 +1,6 @@
 use std::collections::HashMap;
 use std::io::Write;
 
-#[cfg(test)]
-use fake::Fake;
-
 use crate::{
     codec::{Decoder, Encoder},
     error::{DecodeError, EncodeError},

--- a/protocol/src/commands/superstream_partitions.rs
+++ b/protocol/src/commands/superstream_partitions.rs
@@ -1,8 +1,5 @@
 use std::io::Write;
 
-#[cfg(test)]
-use fake::Fake;
-
 use super::Command;
 use crate::{
     codec::{Decoder, Encoder},

--- a/protocol/src/commands/superstream_route.rs
+++ b/protocol/src/commands/superstream_route.rs
@@ -1,8 +1,5 @@
 use std::io::Write;
 
-#[cfg(test)]
-use fake::Fake;
-
 use crate::{
     codec::{Decoder, Encoder},
     error::{DecodeError, EncodeError},

--- a/protocol/src/commands/tune.rs
+++ b/protocol/src/commands/tune.rs
@@ -9,9 +9,6 @@ use crate::{
 
 use super::Command;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[cfg_attr(test, derive(fake::Dummy))]
 #[derive(PartialEq, Eq, Debug)]
 pub struct TunesCommand {

--- a/protocol/src/commands/unsubscribe.rs
+++ b/protocol/src/commands/unsubscribe.rs
@@ -1,8 +1,5 @@
 use std::io::Write;
 
-#[cfg(test)]
-use fake::Fake;
-
 use crate::{
     codec::{Decoder, Encoder},
     error::{DecodeError, EncodeError},

--- a/protocol/src/message/amqp/body.rs
+++ b/protocol/src/message/amqp/body.rs
@@ -78,7 +78,7 @@ mod tests {
 
     use super::MessageBody;
     impl Dummy<Faker> for MessageBody {
-        fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+        fn dummy_with_rng<R: fake::rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
             MessageBody {
                 data: config.fake_with_rng(rng),
                 sequence: config.fake_with_rng(rng),

--- a/protocol/src/message/amqp/header.rs
+++ b/protocol/src/message/amqp/header.rs
@@ -11,9 +11,6 @@ use super::{
     types::{list_decoder, Boolean, List},
     AmqpDecodeError, AmqpDecoder, AmqpEncodeError, AmqpEncoder,
 };
-#[cfg(test)]
-use fake::Fake;
-
 /// Header of the message
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(test, derive(fake::Dummy))]

--- a/protocol/src/message/amqp/message.rs
+++ b/protocol/src/message/amqp/message.rs
@@ -11,9 +11,6 @@ use super::section::MessageSection;
 use super::types::{ApplicationProperties, DeliveryAnnotations, Footer, MessageAnnotations};
 use super::{AmqpDecodeError, AmqpDecoder};
 
-#[cfg(test)]
-use fake::Fake;
-
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(test, derive(fake::Dummy))]
 pub struct Message {

--- a/protocol/src/message/amqp/mod.rs
+++ b/protocol/src/message/amqp/mod.rs
@@ -52,7 +52,7 @@ mod tests {
     where
         T: Dummy<Faker> + AmqpDecoder + AmqpEncoder + Debug + PartialEq,
     {
-        let mut rng = rand::thread_rng();
+        let mut rng = fake::rand::rng();
         let len: usize = DEFAULT_LEN_RANGE.fake_with_rng(&mut rng);
 
         for _ in 0..len {

--- a/protocol/src/message/amqp/properties.rs
+++ b/protocol/src/message/amqp/properties.rs
@@ -15,9 +15,6 @@ use super::{
     AmqpEncodeError, AmqpEncoder,
 };
 
-#[cfg(test)]
-use fake::Fake;
-
 /// Properties of the message
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(test, derive(fake::Dummy))]

--- a/protocol/src/message/amqp/types/annotations.rs
+++ b/protocol/src/message/amqp/types/annotations.rs
@@ -4,8 +4,6 @@ use crate::{
 };
 
 use super::{Long, Map, Symbol, ULong, Value};
-#[cfg(test)]
-use fake::Fake;
 
 /// Key for annotations [`Map`]
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/protocol/src/message/amqp/types/descriptor.rs
+++ b/protocol/src/message/amqp/types/descriptor.rs
@@ -5,9 +5,6 @@ use crate::message::amqp::codec::{AmqpDecoder, AmqpEncoder};
 use crate::message::amqp::error::{AmqpDecodeError, AmqpEncodeError};
 use crate::utils::TupleMapperSecond;
 
-#[cfg(test)]
-use fake::Fake;
-
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 #[cfg_attr(test, derive(fake::Dummy))]
 pub enum Descriptor {

--- a/protocol/src/message/amqp/types/mod.rs
+++ b/protocol/src/message/amqp/types/mod.rs
@@ -6,9 +6,6 @@ pub use primitives::*;
 
 use super::{codec::constants::TypeCode, AmqpDecoder, AmqpEncodeError, AmqpEncoder};
 
-#[cfg(test)]
-use fake::Fake;
-
 mod annotations;
 mod definitions;
 mod descriptor;

--- a/protocol/src/message/amqp/types/primitives/list.rs
+++ b/protocol/src/message/amqp/types/primitives/list.rs
@@ -168,7 +168,6 @@ mod tests {
     use std::ops::Range;
 
     use fake::{Dummy, Fake, Faker};
-    use rand::Rng;
 
     use crate::message::amqp::{
         tests::type_encode_decode_test_fuzzy,
@@ -179,7 +178,7 @@ mod tests {
     const DEFAULT_LEN_RANGE: Range<usize> = 0..10;
 
     impl Dummy<Faker> for List {
-        fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+        fn dummy_with_rng<R: fake::rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
             let len: usize = DEFAULT_LEN_RANGE.fake_with_rng(rng);
             let mut m = List::new();
 

--- a/protocol/src/message/amqp/types/primitives/map.rs
+++ b/protocol/src/message/amqp/types/primitives/map.rs
@@ -132,7 +132,6 @@ mod tests {
     use crate::message::amqp::types::{SimpleValue, Value};
 
     use fake::{Dummy, Fake, Faker};
-    use rand::Rng;
 
     use std::{hash::Hash, ops::Range};
 
@@ -142,7 +141,7 @@ mod tests {
     where
         K: Dummy<Faker> + Hash + Eq,
     {
-        fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+        fn dummy_with_rng<R: fake::rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
             let len: usize = DEFAULT_LEN_RANGE.fake_with_rng(rng);
             let mut m = Map::default();
 
@@ -154,7 +153,7 @@ mod tests {
         }
 
         fn dummy(config: &Faker) -> Self {
-            let mut r = rand::thread_rng();
+            let mut r = fake::rand::rng();
             Dummy::<Faker>::dummy_with_rng(config, &mut r)
         }
     }
@@ -163,7 +162,7 @@ mod tests {
     where
         K: Dummy<Faker> + Hash + Eq,
     {
-        fn dummy_with_rng<R: Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+        fn dummy_with_rng<R: fake::rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
             let len: usize = DEFAULT_LEN_RANGE.fake_with_rng(rng);
             let mut m = Map::default();
 
@@ -175,7 +174,7 @@ mod tests {
         }
 
         fn dummy(config: &Faker) -> Self {
-            let mut r = rand::thread_rng();
+            let mut r = fake::rand::rng();
             Dummy::<Faker>::dummy_with_rng(config, &mut r)
         }
     }

--- a/protocol/src/message/amqp/types/primitives/simple.rs
+++ b/protocol/src/message/amqp/types/primitives/simple.rs
@@ -17,9 +17,6 @@ use crate::{
     utils::TupleMapperSecond,
 };
 
-#[cfg(test)]
-use fake::Fake;
-
 /// Primitive AMQP 1.0 data type
 #[derive(Debug, Eq, PartialEq, Hash, Clone, From, TryInto)]
 #[try_into(owned, ref, ref_mut)]
@@ -691,20 +688,20 @@ mod tests {
     use crate::message::amqp::{tests::type_encode_decode_test_fuzzy, types::SimpleValue};
 
     impl Dummy<Faker> for Float {
-        fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+        fn dummy_with_rng<R: fake::rand::RngCore + ?Sized>(config: &Faker, rng: &mut R) -> Self {
             let num: f32 = config.fake_with_rng(rng);
             Float(OrderedFloat::from(num))
         }
     }
     impl Dummy<Faker> for Double {
-        fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+        fn dummy_with_rng<R: fake::rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
             let num: f64 = config.fake_with_rng(rng);
             Double(OrderedFloat::from(num))
         }
     }
 
     impl Dummy<Faker> for Timestamp {
-        fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
+        fn dummy_with_rng<R: fake::rand::Rng + ?Sized>(config: &Faker, rng: &mut R) -> Self {
             let mut dt: DateTime<Utc> = config.fake_with_rng(rng);
             dt = dt.with_nanosecond(0).unwrap();
             Timestamp(dt)

--- a/protocol/src/message/amqp/types/primitives/value.rs
+++ b/protocol/src/message/amqp/types/primitives/value.rs
@@ -14,9 +14,6 @@ use crate::{
 };
 use derive_more::From;
 
-#[cfg(test)]
-use fake::Fake;
-
 /// AMQP 1.0 data types
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
 #[cfg_attr(test, derive(fake::Dummy))]

--- a/protocol/src/message/amqp/types/symbol.rs
+++ b/protocol/src/message/amqp/types/symbol.rs
@@ -10,8 +10,6 @@ use crate::{
 };
 
 use byteorder::{BigEndian, WriteBytesExt};
-#[cfg(test)]
-use fake::Fake;
 
 use super::Str;
 

--- a/protocol/src/request/mod.rs
+++ b/protocol/src/request/mod.rs
@@ -244,9 +244,9 @@ mod tests {
     use crate::{
         codec::{Decoder, Encoder},
         commands::{
-            close::CloseRequest, consumer_update_request::ConsumerUpdateRequestCommand,
-            create_stream::CreateStreamCommand, create_super_stream::CreateSuperStreamCommand,
-            credit::CreditCommand, declare_publisher::DeclarePublisherCommand, delete::Delete,
+            close::CloseRequest, create_stream::CreateStreamCommand,
+            create_super_stream::CreateSuperStreamCommand, credit::CreditCommand,
+            declare_publisher::DeclarePublisherCommand, delete::Delete,
             delete_publisher::DeletePublisherCommand,
             delete_super_stream::DeleteSuperStreamCommand,
             exchange_command_versions::ExchangeCommandVersionsRequest,

--- a/protocol/src/response/mod.rs
+++ b/protocol/src/response/mod.rs
@@ -223,8 +223,6 @@ where
 #[cfg(test)]
 mod tests {
 
-    use std::collections::HashMap;
-
     use byteorder::{BigEndian, WriteBytesExt};
 
     use super::{Response, ResponseKind};

--- a/protocol/src/types.rs
+++ b/protocol/src/types.rs
@@ -20,9 +20,6 @@ impl Header {
     }
 }
 
-#[cfg(test)]
-use fake::Fake;
-
 use crate::{message::Message, ResponseCode};
 
 #[cfg_attr(test, derive(fake::Dummy))]


### PR DESCRIPTION
`send` method should accept a `FnOnce` because the callback is invoked only once, after the error or ack from the server.
This PR implements the check on the type system.

NB: this is a **breaking change**

```rust
    // A non copy structure
    struct Foo;

    let f = Foo;
    producer
        .send(
            Message::builder().body(b"message".to_vec()).build(),
            move |_| {
                // this callback is an FnOnce, so we can drop a value here
                drop(f);
                async {}
            },
        )
        .await
        .unwrap();
```

Implementation details:
This PR uses an enum to store an `OnceProducerMessageWaiter` or a `SharedProducerMessageWaiter`. Only the latter is clonable.

Other:
update `fake` to 4