### PR TITLE
Dynamic send

### DIFF
--- a/.tarpaulin.toml
+++ b/.tarpaulin.toml
@@ -4,6 +4,7 @@ exclude-files=[
     "benchmark/*",
     "build.rs",
     "src/lib.rs",
+    "src/bin/**/*.rs",
     "tests/**/*",
     "mod.rs"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,6 @@ path="examples/superstreams/send_super_stream.rs"
 name="environment_deserialization"
 path="examples/environment_deserialization.rs"
 
+[[bin]]
+name = "perf-producer"
+path = "src/bin/perf-producer.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ tracing-subscriber = "0.3.1"
 fake = { version = "3.0.0", features = ['derive'] }
 chrono = "0.4.26"
 serde_json = "1.0"
+reqwest = { version = "0.12", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
 
 [features]
 default = []

--- a/examples/send_async.rs
+++ b/examples/send_async.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let create_response = environment
         .stream_creator()
         .max_length(ByteCapacity::GB(5))
-        .create(&stream)
+        .create(stream)
         .await;
 
     if let Err(e) = create_response {

--- a/examples/tls_producer.rs
+++ b/examples/tls_producer.rs
@@ -54,9 +54,9 @@ async fn start_publisher(
     env: Environment,
     stream: &String,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let _ = env.stream_creator().create(&stream).await;
+    let _ = env.stream_creator().create(stream).await;
 
-    let producer = env.producer().batch_size(BATCH_SIZE).build(&stream).await?;
+    let producer = env.producer().batch_size(BATCH_SIZE).build(stream).await?;
 
     let is_batch_send = true;
     tokio::task::spawn(async move {

--- a/protocol/src/message/builder.rs
+++ b/protocol/src/message/builder.rs
@@ -30,7 +30,7 @@ impl MessageBuilder {
     pub fn application_properties(self) -> ApplicationPropertiesBuider {
         ApplicationPropertiesBuider(self)
     }
-    pub fn publising_id(mut self, publishing_id: u64) -> Self {
+    pub fn publishing_id(mut self, publishing_id: u64) -> Self {
         self.0.publishing_id = Some(publishing_id);
         self
     }

--- a/src/bin/perf-producer.rs
+++ b/src/bin/perf-producer.rs
@@ -1,0 +1,175 @@
+#![allow(dead_code)]
+
+use std::{
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use rabbitmq_stream_client::{
+    types::{ByteCapacity, Message, OffsetSpecification},
+    Environment,
+};
+use tokio::{sync::mpsc::UnboundedSender, time::sleep};
+use tokio_stream::StreamExt;
+
+static ONE_SECOND: Duration = Duration::from_secs(1);
+static ONE_MINUTE: Duration = Duration::from_secs(60);
+
+struct Metric {
+    created_at: u128,
+    received_at: SystemTime,
+}
+
+#[derive(Debug)]
+struct Stats {
+    average_latency: f32,
+    messages_received: usize,
+}
+
+#[tokio::main]
+async fn main() {
+    let stream_name = "perf-stream";
+
+    let environment = Environment::builder().build().await.unwrap();
+    let _ = environment.delete_stream(stream_name).await;
+    environment
+        .stream_creator()
+        .max_length(ByteCapacity::GB(5))
+        .create(stream_name)
+        .await
+        .unwrap();
+
+    let environment = Arc::new(environment);
+
+    let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+    let consumer_env = environment.clone();
+    let consumer_handler = tokio::spawn(async move {
+        start_consumer(consumer_env, stream_name, sender).await;
+    });
+
+    let produced_messages = AtomicU32::new(0);
+    let producer_env = environment.clone();
+    let producer_handler = tokio::spawn(async move {
+        start_producer(producer_env, stream_name, &produced_messages).await;
+    });
+
+    let run_for = Duration::from_secs(5 * 60);
+
+    tokio::spawn(async move {
+        sleep(run_for).await;
+        producer_handler.abort();
+        sleep(Duration::from_secs(1)).await;
+        consumer_handler.abort();
+    });
+
+    let minutes = run_for.as_secs() / 60;
+
+    let mut now = Instant::now();
+    // 5 minutes of metrics
+    let mut metrics = Vec::with_capacity(50 * 60 * minutes as usize);
+    while let Some(metric) = receiver.recv().await {
+        if now.elapsed() > ONE_MINUTE {
+            now = Instant::now();
+
+            let last_metrics = metrics;
+            metrics = Vec::with_capacity(50 * 60 * minutes as usize);
+            tokio::spawn(async move {
+                let stats = calculate_stats(last_metrics).await;
+                println!("stats: {:?}", stats);
+            });
+        }
+        metrics.push(metric);
+    }
+
+    let stats = calculate_stats(metrics).await;
+    println!("stats: {:?}", stats);
+}
+
+async fn calculate_stats(metrics: Vec<Metric>) -> Stats {
+    let mut total_latency = 0;
+    let metric_count = metrics.len();
+    for metric in metrics {
+        let created_at = SystemTime::UNIX_EPOCH + Duration::from_millis(metric.created_at as u64);
+        let received_at = metric.received_at;
+        let delta = received_at.duration_since(created_at).unwrap();
+        total_latency += delta.as_millis();
+    }
+
+    Stats {
+        average_latency: total_latency as f32 / metric_count as f32,
+        messages_received: metric_count,
+    }
+}
+
+async fn start_consumer(
+    environment: Arc<Environment>,
+    stream_name: &str,
+    sender: UnboundedSender<Metric>,
+) {
+    let mut consumer = environment
+        .consumer()
+        .offset(OffsetSpecification::First)
+        .build(stream_name)
+        .await
+        .unwrap();
+    while let Some(Ok(delivery)) = consumer.next().await {
+        let produced_at = delivery
+            .message()
+            .data()
+            .map(|data| {
+                u128::from_be_bytes([
+                    data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+                    data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15],
+                ])
+            })
+            .unwrap();
+        let metric = Metric {
+            created_at: produced_at,
+            received_at: SystemTime::now(),
+        };
+        sender.send(metric).unwrap();
+    }
+}
+
+async fn start_producer(
+    environment: Arc<Environment>,
+    stream_name: &str,
+    produced_messages: &AtomicU32,
+) {
+    let message_per_second = 50_usize;
+    let producer = environment.producer().build(stream_name).await.unwrap();
+
+    loop {
+        let start = Instant::now();
+        let messages = create_messages(message_per_second);
+        let messages_sent = messages.len() as u32;
+        for message in messages {
+            producer.send(message, |_| async {}).await.unwrap();
+        }
+        produced_messages.fetch_add(messages_sent, Ordering::Relaxed);
+
+        let elapsed = start.elapsed();
+
+        if ONE_SECOND > elapsed {
+            sleep(ONE_SECOND - elapsed).await;
+        }
+    }
+}
+
+fn create_messages(message_count_per_batch: usize) -> Vec<Message> {
+    (0..message_count_per_batch)
+        .map(|_| {
+            let start = SystemTime::now();
+            let since_the_epoch = start
+                .duration_since(UNIX_EPOCH)
+                .expect("Time went backwards");
+            let since_the_epoch = since_the_epoch.as_millis();
+            Message::builder()
+                .body(since_the_epoch.to_be_bytes())
+                .build()
+        })
+        .collect()
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -622,7 +622,7 @@ impl Client {
         M: FnOnce(u32) -> R,
     {
         let Some((correlation_id, mut receiver)) = self.dispatcher.response_channel() else {
-            trace!("Connection si closed here");
+            trace!("Connection is closed here");
             return Err(ClientError::ConnectionClosed);
         };
 

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -223,6 +223,11 @@ impl ClientOptionsBuilder {
         self
     }
 
+    pub fn client_provided_name(mut self, client_provided_name: String) -> Self {
+        self.0.client_provided_name = client_provided_name;
+        self
+    }
+
     pub fn collector(mut self, collector: Arc<dyn MetricsCollector>) -> Self {
         self.0.collector = collector;
         self

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -587,7 +587,7 @@ mod tests {
         assert_eq!(options.heartbeat, 10000);
         assert_eq!(options.max_frame_size, 1);
         assert!(matches!(options.tls, TlsConfiguration::Untrusted));
-        assert_eq!(options.load_balancer_mode, true);
+        assert!(options.load_balancer_mode);
     }
 
     #[cfg(feature = "serde")]

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
-use std::time::Duration;
 
 use crate::types::OffsetSpecification;
 use crate::{client::TlsConfiguration, producer::NoDedup};
@@ -197,7 +196,6 @@ impl Environment {
             environment: self.clone(),
             name: None,
             batch_size: 100,
-            batch_publishing_delay: Duration::from_millis(100),
             data: PhantomData,
             filter_value_extractor: None,
             client_provided_name: String::from("rust-stream-producer"),

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -326,6 +326,7 @@ impl EnvironmentBuilder {
         self.0.client_options.heartbeat = heartbeat;
         self
     }
+
     pub fn metrics_collector(
         mut self,
         collector: impl MetricsCollector + 'static,

--- a/src/error.rs
+++ b/src/error.rs
@@ -109,6 +109,8 @@ pub enum ProducerPublishError {
     Confirmation { stream: String },
     #[error(transparent)]
     Client(#[from] ClientError),
+    #[error("Failed to publish message, timeout")]
+    Timeout,
 }
 
 #[derive(Error, Debug)]

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -609,21 +609,13 @@ impl MessageHandler for ProducerConfirmHandler {
     }
 }
 
-async fn invoke_handler<T>(
-    f: T,
+async fn invoke_handler(
+    f: ArcConfirmCallback,
     publishing_id: u64,
     confirmed: bool,
     status: ResponseCode,
     message: Message,
-) where
-    T: std::ops::Deref<
-        Target = dyn Fn(
-            Result<ConfirmationStatus, ProducerPublishError>,
-        ) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send>>
-                     + Send
-                     + Sync,
-    >,
-{
+) {
     f(Ok(ConfirmationStatus {
         publishing_id,
         confirmed,
@@ -633,13 +625,7 @@ async fn invoke_handler<T>(
     .await;
 }
 async fn invoke_handler_once(
-    f: Box<
-        dyn FnOnce(
-                Result<ConfirmationStatus, ProducerPublishError>,
-            ) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send>>
-            + Send
-            + Sync,
-    >,
+    f: ConfirmCallback,
     publishing_id: u64,
     confirmed: bool,
     status: ResponseCode,

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -12,7 +12,10 @@ use rabbitmq_stream_client::{
     Client, ClientOptions,
 };
 
-use crate::common::TestClient;
+#[path = "./common.rs"]
+mod common;
+
+use common::*;
 
 #[tokio::test]
 async fn client_connection_test() {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -138,7 +138,6 @@ impl Drop for TestEnvironment {
         }
         if self.super_stream != "" {
             tokio::task::block_in_place(|| {
-                println!("Deleting super stream: {}", self.super_stream);
                 tokio::runtime::Handle::current().block_on(async {
                     self.env
                         .delete_super_stream(&self.super_stream)

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -79,20 +79,17 @@ impl Drop for TestClient {
         if self.stream != "" {
             tokio::task::block_in_place(|| {
                 tokio::runtime::Handle::current().block_on(async {
-                    let r = self.client.delete_stream(&self.stream).await;
-                    if let Err(e) = r {
-                        eprintln!("Error deleting stream: {:?}", e);
-                    }
+                    self.client.delete_stream(&self.stream).await.unwrap();
                 })
             });
         }
         if self.super_stream != "" {
             tokio::task::block_in_place(|| {
                 tokio::runtime::Handle::current().block_on(async {
-                    let r = self.client.delete_super_stream(&self.super_stream).await;
-                    if let Err(e) = r {
-                        eprintln!("Error deleting super stream: {:?}", e);
-                    }
+                    self.client
+                        .delete_super_stream(&self.super_stream)
+                        .await
+                        .unwrap();
                 })
             });
         }
@@ -135,12 +132,7 @@ impl Drop for TestEnvironment {
         if self.stream != "" {
             tokio::task::block_in_place(|| {
                 tokio::runtime::Handle::current().block_on(async {
-                    let r = self.env.delete_stream(&self.stream).await;
-                    // Since we generate stream name randomly,
-                    // it doesn't matter if the deletion goes wrong
-                    if let Err(e) = r {
-                        eprintln!("Error deleting stream: {:?}", e);
-                    }
+                    self.env.delete_stream(&self.stream).await.unwrap();
                 })
             });
         }
@@ -148,12 +140,10 @@ impl Drop for TestEnvironment {
             tokio::task::block_in_place(|| {
                 println!("Deleting super stream: {}", self.super_stream);
                 tokio::runtime::Handle::current().block_on(async {
-                    let r = self.env.delete_super_stream(&self.super_stream).await;
-                    // Since we generate super stream name randomly,
-                    // it doesn't matter if the deletion goes wrong
-                    if let Err(e) = r {
-                        eprintln!("Error deleting super stream: {:?}", e);
-                    }
+                    self.env
+                        .delete_super_stream(&self.super_stream)
+                        .await
+                        .unwrap();
                 })
             });
         }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -76,14 +76,16 @@ impl TestClient {
 
 impl Drop for TestClient {
     fn drop(&mut self) {
-        if self.stream != "" {
+        if !self.stream.is_empty() {
             tokio::task::block_in_place(|| {
                 tokio::runtime::Handle::current().block_on(async {
-                    self.client.delete_stream(&self.stream).await.unwrap();
+                    // Some tests may close the connection intentionally
+                    // so we ignore the error here
+                    let _ = self.client.delete_stream(&self.stream).await;
                 })
             });
         }
-        if self.super_stream != "" {
+        if !self.super_stream.is_empty() {
             tokio::task::block_in_place(|| {
                 tokio::runtime::Handle::current().block_on(async {
                     self.client
@@ -129,14 +131,14 @@ impl TestEnvironment {
 
 impl Drop for TestEnvironment {
     fn drop(&mut self) {
-        if self.stream != "" {
+        if !self.stream.is_empty() {
             tokio::task::block_in_place(|| {
                 tokio::runtime::Handle::current().block_on(async {
                     self.env.delete_stream(&self.stream).await.unwrap();
                 })
             });
         }
-        if self.super_stream != "" {
+        if !self.super_stream.is_empty() {
             tokio::task::block_in_place(|| {
                 tokio::runtime::Handle::current().block_on(async {
                     self.env
@@ -166,7 +168,7 @@ pub async fn create_generic_super_stream(
 
     let response = client
         .create_super_stream(
-            &super_stream,
+            super_stream,
             partitions.clone(),
             binding_keys,
             HashMap::new(),
@@ -174,5 +176,5 @@ pub async fn create_generic_super_stream(
         .await
         .unwrap();
 
-    return (response, partitions);
+    (response, partitions)
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -78,17 +78,21 @@ impl Drop for TestClient {
     fn drop(&mut self) {
         if self.stream != "" {
             tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current()
-                    .block_on(async { self.client.delete_stream(&self.stream).await.unwrap() })
+                tokio::runtime::Handle::current().block_on(async {
+                    let r = self.client.delete_stream(&self.stream).await;
+                    if let Err(e) = r {
+                        eprintln!("Error deleting stream: {:?}", e);
+                    }
+                })
             });
         }
         if self.super_stream != "" {
             tokio::task::block_in_place(|| {
                 tokio::runtime::Handle::current().block_on(async {
-                    self.client
-                        .delete_super_stream(&self.super_stream)
-                        .await
-                        .unwrap()
+                    let r = self.client.delete_super_stream(&self.super_stream).await;
+                    if let Err(e) = r {
+                        eprintln!("Error deleting super stream: {:?}", e);
+                    }
                 })
             });
         }
@@ -130,17 +134,26 @@ impl Drop for TestEnvironment {
     fn drop(&mut self) {
         if self.stream != "" {
             tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current()
-                    .block_on(async { self.env.delete_stream(&self.stream).await.unwrap() })
+                tokio::runtime::Handle::current().block_on(async {
+                    let r = self.env.delete_stream(&self.stream).await;
+                    // Since we generate stream name randomly,
+                    // it doesn't matter if the deletion goes wrong
+                    if let Err(e) = r {
+                        eprintln!("Error deleting stream: {:?}", e);
+                    }
+                })
             });
         }
         if self.super_stream != "" {
             tokio::task::block_in_place(|| {
+                println!("Deleting super stream: {}", self.super_stream);
                 tokio::runtime::Handle::current().block_on(async {
-                    self.env
-                        .delete_super_stream(&self.super_stream)
-                        .await
-                        .unwrap()
+                    let r = self.env.delete_super_stream(&self.super_stream).await;
+                    // Since we generate super stream name randomly,
+                    // it doesn't matter if the deletion goes wrong
+                    if let Err(e) = r {
+                        eprintln!("Error deleting super stream: {:?}", e);
+                    }
                 })
             });
         }

--- a/tests/consumer_test.rs
+++ b/tests/consumer_test.rs
@@ -1,6 +1,10 @@
 use std::time::Duration;
 
-use crate::common::TestEnvironment;
+#[path = "./common.rs"]
+mod common;
+
+use common::*;
+
 use fake::{Fake, Faker};
 use futures::StreamExt;
 use rabbitmq_stream_client::{
@@ -12,7 +16,6 @@ use rabbitmq_stream_client::{
     Consumer, FilterConfiguration, NoDedup, Producer,
 };
 
-use crate::producer_test::routing_key_strategy_value_extractor;
 use rabbitmq_stream_client::types::{
     HashRoutingMurmurStrategy, RoutingKeyRoutingStrategy, RoutingStrategy,
 };
@@ -21,6 +24,10 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use tokio::sync::Notify;
 use tokio::task;
 use {std::sync::Arc, std::sync::Mutex};
+
+pub fn routing_key_strategy_value_extractor(_: &Message) -> String {
+    return "0".to_string();
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn consumer_test() {
@@ -66,7 +73,7 @@ fn hash_strategy_value_extractor(message: &Message) -> String {
     let s = String::from_utf8(Vec::from(message.data().unwrap())).expect("Found invalid UTF-8");
     return s;
 }
-
+/*
 #[tokio::test(flavor = "multi_thread")]
 async fn super_stream_consumer_test() {
     let env = TestEnvironment::create_super_stream().await;
@@ -115,6 +122,7 @@ async fn super_stream_consumer_test() {
     super_stream_producer.close().await.unwrap();
     _ = handle.close().await;
 }
+*/
 
 #[tokio::test(flavor = "multi_thread")]
 async fn consumer_test_offset_specification_offset() {

--- a/tests/consumer_test.rs
+++ b/tests/consumer_test.rs
@@ -73,7 +73,7 @@ fn hash_strategy_value_extractor(message: &Message) -> String {
     let s = String::from_utf8(Vec::from(message.data().unwrap())).expect("Found invalid UTF-8");
     return s;
 }
-/*
+
 #[tokio::test(flavor = "multi_thread")]
 async fn super_stream_consumer_test() {
     let env = TestEnvironment::create_super_stream().await;
@@ -122,7 +122,6 @@ async fn super_stream_consumer_test() {
     super_stream_producer.close().await.unwrap();
     _ = handle.close().await;
 }
-*/
 
 #[tokio::test(flavor = "multi_thread")]
 async fn consumer_test_offset_specification_offset() {

--- a/tests/consumer_test.rs
+++ b/tests/consumer_test.rs
@@ -26,7 +26,7 @@ use tokio::task;
 use {std::sync::Arc, std::sync::Mutex};
 
 pub fn routing_key_strategy_value_extractor(_: &Message) -> String {
-    return "0".to_string();
+    "0".to_string()
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -71,7 +71,7 @@ async fn consumer_test() {
 
 fn hash_strategy_value_extractor(message: &Message) -> String {
     let s = String::from_utf8(Vec::from(message.data().unwrap())).expect("Found invalid UTF-8");
-    return s;
+    s
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -101,7 +101,7 @@ async fn super_stream_consumer_test() {
 
     for n in 0..message_count {
         let msg = Message::builder().body(format!("message{}", n)).build();
-        let _ = super_stream_producer
+        super_stream_producer
             .send(msg, |_confirmation_status| async move {})
             .await
             .unwrap();
@@ -111,7 +111,7 @@ async fn super_stream_consumer_test() {
     let handle = super_stream_consumer.handle();
 
     while let Some(_) = super_stream_consumer.next().await {
-        received_messages = received_messages + 1;
+        received_messages += 1;
         if received_messages == 10 {
             break;
         }
@@ -288,13 +288,10 @@ async fn consumer_create_stream_not_existing_error() {
     let consumer = env.env.consumer().build("stream_not_existing").await;
 
     match consumer {
-        Err(e) => assert_eq!(
-            matches!(
-                e,
-                rabbitmq_stream_client::error::ConsumerCreateError::StreamDoesNotExist { .. }
-            ),
-            true
-        ),
+        Err(e) => assert!(matches!(
+            e,
+            rabbitmq_stream_client::error::ConsumerCreateError::StreamDoesNotExist { .. }
+        )),
         _ => panic!("Should be StreamNotFound error"),
     }
 }
@@ -444,7 +441,7 @@ async fn consumer_test_with_filtering() {
     let filter_configuration = FilterConfiguration::new(vec!["filtering".to_string()], false)
         .post_filter(|message| {
             String::from_utf8(message.data().unwrap().to_vec()).unwrap_or("".to_string())
-                == "filtering".to_string()
+                == *"filtering"
         });
 
     let mut consumer = env
@@ -521,7 +518,7 @@ async fn super_stream_consumer_test_with_filtering() {
     let filter_configuration = FilterConfiguration::new(vec!["filtering".to_string()], false)
         .post_filter(|message| {
             String::from_utf8(message.data().unwrap().to_vec()).unwrap_or("".to_string())
-                == "filtering".to_string()
+                == *"filtering"
         });
 
     let mut super_stream_consumer = env
@@ -629,8 +626,7 @@ async fn consumer_test_with_filtering_match_unfiltered() {
 
     let filter_configuration =
         FilterConfiguration::new(vec!["1".to_string()], true).post_filter(|message| {
-            String::from_utf8(message.data().unwrap().to_vec()).unwrap_or("".to_string())
-                == "1".to_string()
+            String::from_utf8(message.data().unwrap().to_vec()).unwrap_or("".to_string()) == *"1"
         });
 
     let mut consumer = env
@@ -725,7 +721,7 @@ async fn super_stream_single_active_consumer_test() {
 
     for n in 0..message_count {
         let msg = Message::builder().body(format!("message{}", n)).build();
-        let _ = super_stream_producer
+        super_stream_producer
             .send(msg, |_confirmation_status| async move {})
             .await
             .unwrap();
@@ -884,7 +880,7 @@ async fn super_stream_single_active_consumer_test_with_callback() {
 
     for n in 0..message_count {
         let msg = Message::builder().body(format!("message{}", n)).build();
-        let _ = super_stream_producer
+        super_stream_producer
             .send(msg, |_confirmation_status| async move {})
             .await
             .unwrap();

--- a/tests/environment_test.rs
+++ b/tests/environment_test.rs
@@ -52,11 +52,11 @@ async fn environment_create_and_delete_super_stream_test() {
         .create_super_stream(&super_stream, 3, None)
         .await;
 
-    assert_eq!(response.is_ok(), true);
+    assert!(response.is_ok());
 
     let response = env.delete_super_stream(&super_stream).await;
 
-    assert_eq!(response.is_ok(), true);
+    assert!(response.is_ok());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -130,7 +130,7 @@ async fn environment_create_delete_stream_twice() {
     let env = Environment::builder().build().await.unwrap();
     let stream_to_test: String = Faker.fake();
     let response = env.stream_creator().create(&stream_to_test).await;
-    assert_eq!(response.is_ok(), true);
+    assert!(response.is_ok());
 
     let response = env.stream_creator().create(&stream_to_test).await;
 
@@ -144,7 +144,7 @@ async fn environment_create_delete_stream_twice() {
 
     // The first delete should succeed since the stream was created
     let delete_response = env.delete_stream(&stream_to_test).await;
-    assert_eq!(delete_response.is_ok(), true);
+    assert!(delete_response.is_ok());
 
     // the second delete should fail since the stream was already deleted
     let delete_response = env.delete_stream(&stream_to_test).await;
@@ -174,10 +174,10 @@ async fn environment_create_streams_with_parameters() {
         .max_segment_size(ByteCapacity::GB(1))
         .create(&stream_to_test)
         .await;
-    assert_eq!(response.is_ok(), true);
+    assert!(response.is_ok());
 
     let delete_response = env.delete_stream(&stream_to_test).await;
-    assert_eq!(delete_response.is_ok(), true);
+    assert!(delete_response.is_ok());
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/environment_test.rs
+++ b/tests/environment_test.rs
@@ -6,7 +6,10 @@ use rabbitmq_stream_client::types::ByteCapacity;
 use rabbitmq_stream_client::{error, Environment, TlsConfiguration};
 use rabbitmq_stream_protocol::ResponseCode;
 
-use crate::common::TestEnvironment;
+#[path = "./common.rs"]
+mod common;
+
+use common::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn environment_create_test() {
@@ -40,19 +43,21 @@ mod tests {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn environment_create_and_delete_super_stream_test() {
-    let super_stream = "super_stream_test";
+    let super_stream: String = Faker.fake();
     let env = Environment::builder().build().await.unwrap();
 
     let response = env
         .stream_creator()
         .max_length(ByteCapacity::GB(5))
-        .create_super_stream(super_stream, 3, None)
+        .create_super_stream(&super_stream, 3, None)
         .await;
 
+    println!("{:?}", response);
     assert_eq!(response.is_ok(), true);
 
-    let response = env.delete_super_stream(super_stream).await;
+    let response = env.delete_super_stream(&super_stream).await;
 
+    println!("{:?}", response);
     assert_eq!(response.is_ok(), true);
 }
 

--- a/tests/environment_test.rs
+++ b/tests/environment_test.rs
@@ -52,12 +52,10 @@ async fn environment_create_and_delete_super_stream_test() {
         .create_super_stream(&super_stream, 3, None)
         .await;
 
-    println!("{:?}", response);
     assert_eq!(response.is_ok(), true);
 
     let response = env.delete_super_stream(&super_stream).await;
 
-    println!("{:?}", response);
     assert_eq!(response.is_ok(), true);
 }
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,5 +1,0 @@
-mod client_test;
-mod common;
-mod consumer_test;
-mod environment_test;
-mod producer_test;

--- a/tests/producer_test.rs
+++ b/tests/producer_test.rs
@@ -132,7 +132,7 @@ async fn producer_send_name_with_deduplication_ok() {
         .send_with_confirm(
             Message::builder()
                 .body(b"message0".to_vec())
-                .publising_id(0)
+                .publishing_id(0)
                 .build(),
         )
         .await
@@ -173,24 +173,24 @@ async fn producer_send_batch_name_with_deduplication_ok() {
             // confirmed
             Message::builder()
                 .body(b"message".to_vec())
-                .publising_id(0)
+                .publishing_id(0)
                 .build(),
             // this won't be confirmed
             // since it will skipped by deduplication
             Message::builder()
                 .body(b"message".to_vec())
-                .publising_id(0)
+                .publishing_id(0)
                 .build(),
             // confirmed since the publishing id is different
             Message::builder()
                 .body(b"message".to_vec())
-                .publising_id(1)
+                .publishing_id(1)
                 .build(),
             // not confirmed since the publishing id is the same
             // message will be skipped by deduplication
             Message::builder()
                 .body(b"message".to_vec())
-                .publising_id(1)
+                .publishing_id(1)
                 .build(),
         ])
         .await

--- a/tests/producer_test.rs
+++ b/tests/producer_test.rs
@@ -10,7 +10,10 @@ use rabbitmq_stream_client::{
     Environment,
 };
 
-use crate::common::{Countdown, TestEnvironment};
+#[path = "./common.rs"]
+mod common;
+
+use common::*;
 
 use rabbitmq_stream_client::types::{
     HashRoutingMurmurStrategy, RoutingKeyRoutingStrategy, RoutingStrategy,

--- a/tests/producer_test.rs
+++ b/tests/producer_test.rs
@@ -71,7 +71,7 @@ async fn producer_send_name_deduplication_unique_ids() {
         for _ in 0..times {
             let cloned_ids = ids.clone();
             let countdown = countdown.clone();
-            let _ = producer
+            producer
                 .send(
                     Message::builder().body(b"message".to_vec()).build(),
                     move |result| {
@@ -309,7 +309,7 @@ async fn producer_batch_send() {
 
     assert_eq!(1, result.len());
 
-    let confirmation = result.get(0).unwrap();
+    let confirmation = result.first().unwrap();
     assert_eq!(0, confirmation.publishing_id());
     assert!(confirmation.confirmed());
     assert_eq!(Some(b"message".as_ref()), confirmation.message().data());
@@ -414,8 +414,8 @@ async fn producer_send_with_complex_message_ok() {
     );
 
     assert_eq!(
-        Some(1u32.into()),
-        properties.and_then(|properties| properties.group_sequence.clone())
+        Some(1u32),
+        properties.and_then(|properties| properties.group_sequence)
     );
 
     assert_eq!(
@@ -454,13 +454,10 @@ async fn producer_create_stream_not_existing_error() {
     let producer = env.env.producer().build("stream_not_existing").await;
 
     match producer {
-        Err(e) => assert_eq!(
-            matches!(
-                e,
-                rabbitmq_stream_client::error::ProducerCreateError::StreamDoesNotExist { .. }
-            ),
-            true
-        ),
+        Err(e) => assert!(matches!(
+            e,
+            rabbitmq_stream_client::error::ProducerCreateError::StreamDoesNotExist { .. }
+        )),
         _ => panic!("Should be StreamNotFound error"),
     }
 }
@@ -475,22 +472,19 @@ async fn producer_send_after_close_error() {
         .await
         .unwrap_err();
 
-    assert_eq!(
-        matches!(
-            closed,
-            rabbitmq_stream_client::error::ProducerPublishError::Closed
-        ),
-        true
-    );
+    assert!(matches!(
+        closed,
+        rabbitmq_stream_client::error::ProducerPublishError::Closed
+    ));
 }
 
 pub fn routing_key_strategy_value_extractor(_: &Message) -> String {
-    return "0".to_string();
+    "0".to_string()
 }
 
 fn hash_strategy_value_extractor(message: &Message) -> String {
     let s = String::from_utf8(Vec::from(message.data().unwrap())).expect("Found invalid UTF-8");
-    return s;
+    s
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -554,13 +548,10 @@ async fn key_super_steam_non_existing_producer_test() {
         .await
         .unwrap_err();
 
-    assert_eq!(
-        matches!(
-            result,
-            rabbitmq_stream_client::error::SuperStreamProducerPublishError::ProducerCreateError()
-        ),
-        true
-    );
+    assert!(matches!(
+        result,
+        rabbitmq_stream_client::error::SuperStreamProducerPublishError::ProducerCreateError()
+    ));
 
     _ = super_stream_producer.close();
 }
@@ -641,13 +632,10 @@ async fn producer_send_filtering_message() {
 
     let closed = producer.send_with_confirm(message).await.unwrap_err();
 
-    assert_eq!(
-        matches!(
-            closed,
-            rabbitmq_stream_client::error::ProducerPublishError::Closed
-        ),
-        true
-    );
+    assert!(matches!(
+        closed,
+        rabbitmq_stream_client::error::ProducerPublishError::Closed
+    ));
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
This PR implements a new method to send a message:
- `batch_send` follows the same flow as `send`
- every message is queued on a dedicated Tokio task and sent asynchronously
- if the internal producer is closed, the task stops to send
- remove `batch_publishing_delay` params (**breaking**)
- put integration tests under `tests` to avoid parallel execution. Parallel execution causes problems running the tests locally due to the limitation of the OS file description number.
- fix typo on method (publising_id -> publishing_id) (**breaking**)
- add an hardcoded timeout (1sec) to `send_with_confirm`

I introduced also a bin to calculate the latency performance to proof the improvement on low send rate. The bin creates a producer and a consumer. Every minute, 50 messages with the current timestamp are sent to RabbitMQ and the consumer store the metric. Every minute, a log is printed with the statistics.

Before this PR:
```
$ cargo run --release --bin perf-producer
stats: Stats { average_latency: 59.54067, messages_received: 3000 }
stats: Stats { average_latency: 62.840668, messages_received: 3000 }
stats: Stats { average_latency: 58.391335, messages_received: 3000 }
stats: Stats { average_latency: 58.668335, messages_received: 3000 }
```
After this PR:
```
$ cargo run --release --bin perf-producer
stats: Stats { average_latency: 5.1963334, messages_received: 3000 }
stats: Stats { average_latency: 5.195667, messages_received: 3000 }
stats: Stats { average_latency: 5.288, messages_received: 3000 }
stats: Stats { average_latency: 5.148667, messages_received: 3000 }
```