### PR TITLE
Fix doc build failed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["network-programming"]
 readme = "README.md"
 
 [package.metadata."docs.rs"]
+rustdoc-args = ["--cfg", "docsrs"]
 all-features = true
 
 [workspace]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,8 @@
 //! ```
 //! For more consumer options check [`ConsumerBuilder`]
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 mod byte_capacity;
 mod client;
 mod consumer;


### PR DESCRIPTION
I see that the documentation build of the recent versions of docs.rs has failed:

https://docs.rs/crate/rabbitmq-stream-client/0.8.0/builds/1735995


After the repair, this command can run:

```shell
cargo +nightly rustdoc --all-features --lib --open -- --cfg docsrs
```