### PR TITLE
Remove use of `doc(cfg(...))` and the docsrs configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ categories = ["network-programming"]
 readme = "README.md"
 
 [package.metadata."docs.rs"]
-rustdoc-args = ["--cfg", "docsrs"]
 all-features = true
 
 [workspace]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -84,7 +84,6 @@ mod metrics;
 mod options;
 mod task;
 
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio-stream")))]
 #[pin_project(project = StreamProj)]
 #[derive(Debug)]
 pub enum GenericTcpStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,6 @@
 //! ```
 //! For more consumer options check [`ConsumerBuilder`]
 
-#![cfg_attr(docsrs, feature(doc_cfg))]
-
 mod byte_capacity;
 mod client;
 mod consumer;


### PR DESCRIPTION
The documentation build for the crate on docs.rs has been failing with an error that `doc(cfg(...))` is an experimental feature. Instead of fixing this, this changeset removes the only use of the feature from the `GenericTcpStream` enumeration, which is internal and does not show in documentation anyway.