### PR TITLE
Update derive_more requirement from 0.99 to 2.0

### DIFF
--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -16,7 +16,7 @@ ordered-float = "4.1.0"
 uuid = "1"
 chrono = "0.4.26"
 num_enum = "0.7.0"
-derive_more = "0.99"
+derive_more = { version = "2.0.1", features = ["full"] }
 
 [dev-dependencies]
 pretty_assertions = "1.2.0"

--- a/protocol/src/message/amqp/types/primitives/value.rs
+++ b/protocol/src/message/amqp/types/primitives/value.rs
@@ -180,9 +180,9 @@ macro_rules! impl_try_from_simple_value_ref {
             fn try_from(value: &'a Value) -> Result<Self, Self::Error> {
                 use std::convert::TryInto;
                 match value {
-                    Value::Simple(simple) => simple
-                        .try_into()
-                        .map_err(|err: &str| DecodeError::MessageParse(err.to_string())),
+                    Value::Simple(simple) => simple.try_into().map_err(|_| {
+                        DecodeError::MessageParse("Failed to cast Value to simple type".to_string())
+                    }),
                     _ => Err(DecodeError::MessageParse(
                         "Failed to cast Value to simple type".to_string(),
                     )),


### PR DESCRIPTION
The update requires small changes in toml file and a quick fix in value.rs